### PR TITLE
Improve Sync Provider interface to allow external persistence

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -129,44 +129,6 @@ export const rootEntitiesConfig = [
 		// The entity doesn't support selecting multiple records.
 		// The property is maintained for backward compatibility.
 		plural: '__unstableBases',
-		syncConfig: {
-			applyChangesToDoc: ( doc, changes ) => {
-				const content = changes.content?.raw || changes.content;
-				const parsedYdoc =
-					typeof content === 'string'
-						? parseContentYdoc( 'root/base', content )
-						: null; // Note: always use the same 'postType' as this object's config.syncObjectType
-				if ( parsedYdoc !== null ) {
-					// parse content which contains a ydoc, and apply it to the current ydoc. The rest of the attributes can be ignored.
-					Y.transact(
-						doc,
-						() => {
-							// apply remote changes
-							Y.applyUpdate(
-								doc,
-								Y.encodeStateAsUpdate( parsedYdoc )
-							);
-						},
-						'applyChangesToDoc',
-						false
-					);
-				} else {
-					// local changes happened. Apply the differences to the ydoc
-					const ycontent = doc.getMap( 'document' );
-					Object.entries( changes ).forEach( ( [ key, value ] ) => {
-						if (
-							! filteredAttributes.has( key ) &&
-							! fun.equalityDeep( ycontent.get( key ), value )
-						) {
-							ycontent.set( key, value );
-						}
-					} );
-				}
-			},
-			fromCRDTDoc: defaultYdocTransformer,
-			getObjectId: () => 'index',
-			objectType: 'root/base',
-		},
 	},
 	{
 		label: __( 'Post Type' ),
@@ -176,44 +138,6 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/types',
 		baseURLParams: { context: 'edit' },
 		plural: 'postTypes',
-		syncConfig: {
-			applyChangesToDoc: ( ydoc, changes ) => {
-				const content = changes.content?.raw || changes.content;
-				const parsedYdoc =
-					typeof content === 'string'
-						? parseContentYdoc( 'root/postType', content )
-						: null; // Note: always use the same 'postType' as this object's config.syncObjectType
-				if ( parsedYdoc !== null ) {
-					// parse content which contains a ydoc, and apply it to the current ydoc. The rest of the attributes can be ignored.
-					Y.transact(
-						ydoc,
-						() => {
-							// apply remote changes
-							Y.applyUpdate(
-								ydoc,
-								Y.encodeStateAsUpdate( parsedYdoc )
-							);
-						},
-						'applyChangesToDoc',
-						false
-					);
-				} else {
-					// local changes happened. Apply the differences to the ydoc
-					const ycontent = ydoc.getMap( 'document' );
-					Object.entries( changes ).forEach( ( [ key, value ] ) => {
-						if (
-							! filteredAttributes.has( key ) &&
-							! fun.equalityDeep( ycontent.get( key ), value )
-						) {
-							ycontent.set( key, value );
-						}
-					} );
-				}
-			},
-			fromCRDTDoc: defaultYdocTransformer,
-			getObjectId: ( { id } ) => id,
-			objectType: 'root/postType',
-		},
 	},
 	{
 		name: 'media',
@@ -775,44 +699,6 @@ async function loadSiteEntity() {
 		name: 'site',
 		kind: 'root',
 		baseURL: '/wp/v2/settings',
-		syncConfig: {
-			applyChangesToDoc: ( doc, changes ) => {
-				const content = changes.content?.raw || changes.content;
-				const parsedYdoc =
-					typeof content === 'string'
-						? parseContentYdoc( 'root/site', content )
-						: null; // Note: always use the same 'postType' as this object's config.syncObjectType
-				if ( parsedYdoc !== null ) {
-					// parse content which contains a ydoc, and apply it to the current ydoc. The rest of the attributes can be ignored.
-					Y.transact(
-						doc,
-						() => {
-							// apply remote changes
-							Y.applyUpdate(
-								doc,
-								Y.encodeStateAsUpdate( parsedYdoc )
-							);
-						},
-						'applyChangesToDoc',
-						false
-					);
-				} else {
-					// local changes happened. Apply the differences to the ydoc
-					const ycontent = doc.getMap( 'document' );
-					Object.entries( changes ).forEach( ( [ key, value ] ) => {
-						if (
-							! filteredAttributes.has( key ) &&
-							! fun.equalityDeep( ycontent.get( key ), value )
-						) {
-							ycontent.set( key, value );
-						}
-					} );
-				}
-			},
-			fromCRDTDoc: defaultYdocTransformer,
-			getObjectId: () => 'index',
-			objectType: 'root/site',
-		},
 		meta: {},
 	};
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -3,8 +3,7 @@
  */
 import { capitalCase, pascalCase } from 'change-case';
 import { v4 as uuidv4 } from 'uuid';
-import * as string from 'lib0/string';
-import * as sha256 from 'lib0/hash/sha256';
+
 /**
  * WordPress dependencies
  */
@@ -19,82 +18,15 @@ import * as fun from 'lib0/function';
 /**
  * Internal dependencies
  */
-import { getSyncProvider } from './sync';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
 
-// @todo refactor `applyChangesToDoc` implementations this to have less repetition (there are
-// multiple similar implementations)
-
-/**
- * Similar to `parse`, but only reads the Yjs document if available.
- * @param {string} postType
- * @param {string} content
- */
-export function parseContentYdoc( postType, content ) {
-	const newClientId = new Uint32Array(
-		sha256.digest( string.encodeUtf8( content ) ).buffer
-	);
-	const syncProvider = getSyncProvider();
-
-	// It is important that this is a fresh document - don't use the document from the sync package!
-	const ydoc = new Y.Doc( { meta: new Map() } );
-
-	const knownUpdateGuids = new Set();
-	ydoc.meta.set( 'knownRemoteUpdates', knownUpdateGuids );
-	// Changing the Yjs clientid may lead to very weird bugs if done incorrectly.
-	// Please handle the following code-portion with great care!
-	const prevClientId = ydoc.clientID;
-	ydoc.clientID = newClientId;
-	const prevClock = ( ydoc.store.clients.get( newClientId ) || [
-		{ id: { clock: 0 } },
-	] )[ 0 ].id.clock;
-	const blocks = parse( content );
-	syncProvider.configs.get( postType ).applyChangesToDoc( ydoc, {
-		blocks,
-	} );
-	ydoc.clientID = prevClientId;
-	const newClock = ( ydoc.store.clients.get( newClientId ) ?? [
-		{ id: { clock: 0 } },
-	] )[ 0 ].id.clock;
-	if ( prevClock !== newClock ) {
-		// eslint-disable-next-line no-console
-		console.info(
-			'[Yjs Collab] Yjs document was updated to reflect changes to the HTML document.'
-		);
-	}
-	return ydoc;
-}
-
-// only sync what is necessary!
-const filteredAttributes = new Set( [
-	'content',
-	'selection',
-	'excerpt',
-	'date',
-	'date_gmt',
-	'format',
-	'generated_slug',
-	'link',
-	'meta',
-	'modified',
-	'modified_gmt',
-	'slug',
-	'status',
-	'sticky',
-	'tags',
-	'template',
-	'_links',
-	'id',
-	'password',
-	'featured_media',
-] );
-
 /**
  * @param {Y.Doc} ydoc
+ * @return {import('@wordpress/sync').ObjectData} The JSON representation of the document.
  */
-const defaultYdocTransformer = ( ydoc ) => {
+const defaultFromCRDTDoc = ( ydoc ) => {
 	const json = ydoc.getMap( 'document' ).toJSON();
 	if ( json.title?.raw ) {
 		json.title = json.title.raw;
@@ -355,6 +287,20 @@ function makeBlocksSerializable( blocks ) {
  * @return {Promise} Entities promise
  */
 async function loadPostTypeEntities() {
+	const syncedProperties = new Set( [
+		'blocks',
+		'content',
+		'excerpt',
+		'featured_media',
+		'format',
+		'generated_slug',
+		'password',
+		'slug',
+		'sticky',
+		'tags',
+		'template',
+	] );
+
 	const postTypes = await apiFetch( {
 		path: '/wp/v2/types?context=view',
 	} );
@@ -388,267 +334,197 @@ async function loadPostTypeEntities() {
 				 * @param {Y.Doc} ydoc
 				 * @param {any}   changes
 				 */
-				applyChangesToDoc: ( ydoc, changes ) => {
-					const content = changes.content?.raw || changes.content;
-					const parsedYdoc =
-						typeof content === 'string'
-							? parseContentYdoc(
-									'postType/' + postType.name,
-									content
-							  )
-							: null; // Note: always use the same 'postType' as this object's config.syncObjectType
-					if ( parsedYdoc !== null ) {
-						// parse content which contains a ydoc, and apply it to the current ydoc. The rest of the attributes can be ignored.
-						Y.transact(
-							ydoc,
-							() => {
-								// apply remote changes
-								Y.applyUpdate(
-									ydoc,
-									Y.encodeStateAsUpdate( parsedYdoc )
+				applyChangesToCRDTDoc: ( ydoc, changes ) => {
+					// local changes happened. Apply the differences to the ydoc
+					const ycontent = ydoc.getMap( 'document' );
+					Object.entries( changes ).forEach( ( [ key, value ] ) => {
+						if ( typeof value !== 'function' ) {
+							if ( key === 'blocks' ) {
+								if ( ! serialisableBlocksCache.has( value ) ) {
+									serialisableBlocksCache.set(
+										value,
+										makeBlocksSerializable( value )
+									);
+								}
+								const blocks =
+									serialisableBlocksCache.get( value );
+								// This is a rudimentary diff implementation similar to the y-prosemirror diffing
+								// approach.
+								// A better implementation would also diff the textual content and represent it
+								// using a Y.Text type.
+								// However, at this time it makes more sense to keep this algorithm generic to
+								// support all kinds of block types.
+								// Ideally, we ensure that block data structure have a consistent data format.
+								// E.g.:
+								//   - textual content (using rich-text formatting?) may always be stored under `block.text`
+								//   - local information that shouldn't be shared (e.g. clientId or isDragging) is stored under `block.private`
+								if (
+									! ycontent.has( key ) ||
+									ycontent.get( key ) instanceof Array
+								) {
+									// @todo remove the array check
+									ycontent.set( key, new Y.Array() );
+								}
+								/**
+								 * @type {Y.Array<Y.Map<any>>}
+								 */
+								const yblocks = ycontent.get( key );
+								const numOfCommonEntries = math.min(
+									blocks.length,
+									yblocks.length
 								);
-							},
-							'applyChangesToDoc',
-							false
-						);
-					} else {
-						// local changes happened. Apply the differences to the ydoc
-						const ycontent = ydoc.getMap( 'document' );
-						ydoc.transact( () => {
-							Object.entries( changes ).forEach(
-								( [ key, value ] ) => {
-									if ( typeof value !== 'function' ) {
-										if ( key === 'blocks' ) {
+								let left = 0;
+								let right = 0;
+								/**
+								 * @param {any}   gblock
+								 * @param {Y.Map} yblock
+								 */
+								const blocksEqual = ( gblock, yblock ) => {
+									if ( yblock.toJSON ) {
+										yblock = yblock.toJSON();
+									}
+									// we must not sync clientId, as this can't be generated consistenctly and
+									// hence will lead to merge conflicts.
+									const overwrites = {
+										innerBlocks: null,
+										clientId: null,
+									};
+									const res = fun.equalityDeep(
+										Object.assign( {}, gblock, overwrites ),
+										Object.assign( {}, yblock, overwrites )
+									);
+									const inners = gblock.innerBlocks || [];
+									const yinners = yblock.innerBlocks || [];
+									return (
+										res &&
+										inners.length === yinners.length &&
+										inners.every( ( block, i ) =>
+											blocksEqual( block, yinners[ i ] )
+										)
+									);
+								};
+								// skip equal blocks from left
+								for (
+									;
+									left < numOfCommonEntries &&
+									blocksEqual(
+										blocks[ left ],
+										yblocks.get( left )
+									);
+									left++
+								) {
+									/* nop */
+								}
+								// skip equal blocks from right
+								for (
+									;
+									right < numOfCommonEntries - left &&
+									blocksEqual(
+										blocks[ blocks.length - right - 1 ],
+										yblocks.get(
+											yblocks.length - right - 1
+										)
+									);
+									right++
+								) {
+									/* nop */
+								}
+								const numOfUpdatesNeeded =
+									numOfCommonEntries - left - right;
+								const numOfInsertionsNeeded = math.max(
+									0,
+									blocks.length - yblocks.length
+								);
+								const numOfDeletionsNeeded = math.max(
+									0,
+									yblocks.length - blocks.length
+								);
+								// updates
+								for (
+									let i = 0;
+									i < numOfUpdatesNeeded;
+									i++, left++
+								) {
+									const block = blocks[ left ];
+									const yblock = yblocks.get( left );
+									Object.entries( block ).forEach(
+										( [ k, v ] ) => {
 											if (
-												! serialisableBlocksCache.has(
-													value
+												! fun.equalityDeep(
+													block[ k ],
+													yblock.get( k )
 												)
 											) {
-												serialisableBlocksCache.set(
-													value,
-													makeBlocksSerializable(
-														value
-													)
-												);
+												yblock.set( k, v );
 											}
-											const blocks =
-												serialisableBlocksCache.get(
-													value
-												);
-											// This is a rudimentary diff implementation similar to the y-prosemirror diffing
-											// approach.
-											// A better implementation would also diff the textual content and represent it
-											// using a Y.Text type.
-											// However, at this time it makes more sense to keep this algorithm generic to
-											// support all kinds of block types.
-											// Ideally, we ensure that block data structure have a consistent data format.
-											// E.g.:
-											//   - textual content (using rich-text formatting?) may always be stored under `block.text`
-											//   - local information that shouldn't be shared (e.g. clientId or isDragging) is stored under `block.private`
-											if (
-												! ycontent.has( key ) ||
-												ycontent.get( key ) instanceof
-													Array
-											) {
-												// @todo remove the array check
-												ycontent.set(
-													key,
-													new Y.Array()
-												);
-											}
-											/**
-											 * @type {Y.Array<Y.Map<any>>}
-											 */
-											const yblocks = ycontent.get( key );
-											const numOfCommonEntries = math.min(
-												blocks.length,
-												yblocks.length
-											);
-											let left = 0;
-											let right = 0;
-											/**
-											 * @param {any}   gblock
-											 * @param {Y.Map} yblock
-											 */
-											const blocksEqual = (
-												gblock,
-												yblock
-											) => {
-												if ( yblock.toJSON ) {
-													yblock = yblock.toJSON();
-												}
-												// we must not sync clientId, as this can't be generated consistenctly and
-												// hence will lead to merge conflicts.
-												const overwrites = {
-													innerBlocks: null,
-													clientId: null,
-												};
-												const res = fun.equalityDeep(
-													Object.assign(
-														{},
-														gblock,
-														overwrites
-													),
-													Object.assign(
-														{},
-														yblock,
-														overwrites
-													)
-												);
-												const inners =
-													gblock.innerBlocks || [];
-												const yinners =
-													yblock.innerBlocks || [];
-												return (
-													res &&
-													inners.length ===
-														yinners.length &&
-													inners.every(
-														( block, i ) =>
-															blocksEqual(
-																block,
-																yinners[ i ]
-															)
-													)
-												);
-											};
-											// skip equal blocks from left
-											for (
-												;
-												left < numOfCommonEntries &&
-												blocksEqual(
-													blocks[ left ],
-													yblocks.get( left )
-												);
-												left++
-											) {
-												/* nop */
-											}
-											// skip equal blocks from right
-											for (
-												;
-												right <
-													numOfCommonEntries - left &&
-												blocksEqual(
-													blocks[
-														blocks.length -
-															right -
-															1
-													],
-													yblocks.get(
-														yblocks.length -
-															right -
-															1
-													)
-												);
-												right++
-											) {
-												/* nop */
-											}
-											const numOfUpdatesNeeded =
-												numOfCommonEntries -
-												left -
-												right;
-											const numOfInsertionsNeeded =
-												math.max(
-													0,
-													blocks.length -
-														yblocks.length
-												);
-											const numOfDeletionsNeeded =
-												math.max(
-													0,
-													yblocks.length -
-														blocks.length
-												);
-											// updates
-											for (
-												let i = 0;
-												i < numOfUpdatesNeeded;
-												i++, left++
-											) {
-												const block = blocks[ left ];
-												const yblock =
-													yblocks.get( left );
-												Object.entries( block ).forEach(
-													( [ k, v ] ) => {
-														if (
-															! fun.equalityDeep(
-																block[ k ],
-																yblock.get( k )
-															)
-														) {
-															yblock.set( k, v );
-														}
-													}
-												);
-												yblock.forEach( ( _v, k ) => {
-													if (
-														! block.hasOwnProperty(
-															k
-														)
-													) {
-														yblock.delete( k );
-													}
-												} );
-											}
-											// deletes
-											yblocks.delete(
-												left,
-												numOfDeletionsNeeded
-											);
-											// inserts
-											for (
-												let i = 0;
-												i < numOfInsertionsNeeded;
-												i++, left++
-											) {
-												yblocks.insert( left, [
-													new Y.Map(
-														Object.entries(
-															blocks[ left ]
-														)
-													),
-												] );
-											}
-											const knownClientIds = new Set();
-											// remove duplicate clientids
-											for (
-												let j = 0;
-												j < yblocks.length;
-												j++
-											) {
-												const yblock = yblocks.get( j );
-												if (
-													knownClientIds.has(
-														yblock.get( 'clientId' )
-													)
-												) {
-													yblock.set(
-														'clientId',
-														uuidv4()
-													);
-												}
-												knownClientIds.add(
-													yblock.get( 'clientId' )
-												);
-											}
-										} else if (
-											! filteredAttributes.has( key ) &&
-											! fun.equalityDeep(
-												ycontent.get( key ),
-												value
-											)
-										) {
-											ycontent.set( key, value );
 										}
-									}
+									);
+									yblock.forEach( ( _v, k ) => {
+										if ( ! block.hasOwnProperty( k ) ) {
+											yblock.delete( k );
+										}
+									} );
 								}
-							);
-						}, 'gutenberg' );
-					}
+								// deletes
+								yblocks.delete( left, numOfDeletionsNeeded );
+								// inserts
+								for (
+									let i = 0;
+									i < numOfInsertionsNeeded;
+									i++, left++
+								) {
+									yblocks.insert( left, [
+										new Y.Map(
+											Object.entries( blocks[ left ] )
+										),
+									] );
+								}
+								const knownClientIds = new Set();
+								// remove duplicate clientids
+								for ( let j = 0; j < yblocks.length; j++ ) {
+									const yblock = yblocks.get( j );
+									if (
+										knownClientIds.has(
+											yblock.get( 'clientId' )
+										)
+									) {
+										yblock.set( 'clientId', uuidv4() );
+									}
+									knownClientIds.add(
+										yblock.get( 'clientId' )
+									);
+								}
+							} else if (
+								! syncedProperties.has( key ) &&
+								! fun.equalityDeep( ycontent.get( key ), value )
+							) {
+								ycontent.set( key, value );
+							}
+						}
+					} );
 				},
-				fromCRDTDoc: defaultYdocTransformer,
+				fromCRDTDoc: defaultFromCRDTDoc,
+				/**
+				 * This initial object data represents the data that will be synced via
+				 * the CRDT document, which may differ from the entity record. There may
+				 * be properties that should not be synced, or properties that are
+				 * derived from the record.
+				 *
+				 * @param {import('@wordpress/sync').ObjectData} record
+				 * @return {import('@wordpress/sync').ObjectData} The initial data
+				 */
+				getInitialObjectData: ( record ) => {
+					// Mix in the parsed blocks into the record. Only allow properties in
+					// the synced properties set.
+					const content = record.content?.raw ?? record.content ?? '';
+					const blocks = parse( content );
+
+					return Object.fromEntries(
+						Object.entries( { ...record, blocks } ).filter(
+							( [ key ] ) => syncedProperties.has( key )
+						)
+					);
+				},
 				getObjectId: ( { id } ) => id,
 				objectType: 'postType/' + postType.name,
 				supportsAwareness: true,

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -83,16 +83,16 @@ export class SyncProvider {
 	 * Fetch data from local database or remote source.
 	 *
 	 * @param {SyncConfig} syncConfig    Sync configuration for the object type.
-	 * @param {ObjectData} initialData   Initial data to apply to the document.
+	 * @param {ObjectData} record        Record representing this object type.
 	 * @param {Function}   handleChanges Callback to call when data changes.
 	 */
 	public async bootstrap(
 		syncConfig: SyncConfig,
-		initialData: ObjectData,
+		record: ObjectData,
 		handleChanges: ( data: Partial< ObjectData > ) => void
 	): Promise< void > {
 		const ydoc = new Y.Doc( { meta: new Map() } );
-		const objectId = syncConfig.getObjectId( initialData );
+		const objectId = syncConfig.getObjectId( record );
 		const objectType = syncConfig.objectType;
 		const connections = await this.connect( objectId, objectType, ydoc );
 		const entityId = this.getEntityId( objectType, objectId );
@@ -124,7 +124,19 @@ export class SyncProvider {
 			ydoc,
 		} );
 
-		this.update( objectType, initialData, initialData, 'gutenberg' );
+		// Get the initial data to be synced for this record.
+		const initialCRDTDoc = await this.getCRDTDoc( syncConfig, record );
+
+		// Create the initial document, possible from persisted doc.
+		Y.transact(
+			ydoc,
+			() => {
+				// apply remote changes
+				Y.applyUpdate( ydoc, Y.encodeStateAsUpdate( initialCRDTDoc ) );
+			},
+			'syncProvider.bootstrap',
+			false
+		);
 	}
 
 	/**
@@ -157,6 +169,27 @@ export class SyncProvider {
 	}
 
 	/**
+	 * Get the CRDTDoc that represents the initial state of the object data. Custom
+	 * sync providers can override this method to provide a custom initial state.
+	 *
+	 * @param {SyncConfig} syncConfig Sync configuration for the object type.
+	 * @param {ObjectData} record     Initial data to apply to the document.
+	 */
+	protected async getCRDTDoc(
+		syncConfig: SyncConfig,
+		record: ObjectData
+	): Promise< CRDTDoc > {
+		// IMPORTANT: We use a new Yjs document so that the initial state can be
+		// applied to the "real" Yjs document as a singular update.
+		const initialStateDoc = new Y.Doc( { meta: new Map() } );
+
+		const initialData = syncConfig.getInitialObjectData( record );
+		syncConfig.applyChangesToCRDTDoc( initialStateDoc, initialData );
+
+		return initialStateDoc;
+	}
+
+	/**
 	 * Get the undo manager.
 	 *
 	 * @return {UndoManager | null} The undo manager, or null if unsupported.
@@ -179,18 +212,17 @@ export class SyncProvider {
 		changes: Partial< ObjectData >,
 		origin: string
 	): void {
-		const objectId = this.configs.get( objectType )?.getObjectId( record );
+		const syncConfig = this.configs.get( objectType );
+		const objectId = syncConfig?.getObjectId( record );
 
-		if ( ! objectId ) {
+		if ( ! syncConfig || ! objectId ) {
 			return;
 		}
 
 		const entityState = this.getEntityState( objectType, objectId );
 
 		entityState?.ydoc.transact( () => {
-			this.configs
-				.get( objectType )
-				?.applyChangesToDoc( entityState.ydoc, changes );
+			syncConfig.applyChangesToCRDTDoc( entityState.ydoc, changes );
 		}, origin );
 	}
 

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -125,7 +125,10 @@ export class SyncProvider {
 		} );
 
 		// Get the initial data to be synced for this record.
-		const initialCRDTDoc = await this.getCRDTDoc( syncConfig, record );
+		const initialCRDTDoc = await this.getInitialCRDTDoc(
+			syncConfig,
+			record
+		);
 
 		// Create the initial document, possible from persisted doc.
 		Y.transact(
@@ -175,7 +178,7 @@ export class SyncProvider {
 	 * @param {SyncConfig} syncConfig Sync configuration for the object type.
 	 * @param {ObjectData} record     Initial data to apply to the document.
 	 */
-	protected async getCRDTDoc(
+	protected async getInitialCRDTDoc(
 		syncConfig: SyncConfig,
 		record: ObjectData
 	): Promise< CRDTDoc > {

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -25,8 +25,9 @@ export type ConnectDoc = (
 ) => Promise< ConnectDocResult >;
 
 export type SyncConfig = {
-	applyChangesToDoc: ( ydoc: Y.Doc, data: Partial< ObjectData > ) => void;
+	applyChangesToCRDTDoc: ( ydoc: Y.Doc, data: Partial< ObjectData > ) => void;
 	fromCRDTDoc: ( ydoc: Y.Doc ) => ObjectData;
+	getInitialObjectData: ( record: ObjectData ) => ObjectData;
 	getObjectId: ( data: ObjectData ) => ObjectID;
 	objectType: ObjectType;
 	supportsAwareness?: boolean;


### PR DESCRIPTION
- Improve Sync Provider interface to allow "external persistence," meaning persistence in the WordPress DB controlled by an external plugin. The main avenue for this flexibility is the new `SyncProvider#getInitialCRDTDoc` method, which can be overridden by extending `SyncProvider`s. This allows the extending class to first check in post meta for an initial CRDT doc ("shared starting point"). This is crucial for addressing the "initialization problem."
- Remove `SyncConfig`s for non-post entities, since the sync code does not currently work for them anyway.
- Add `SyncConfig#getInitialObjectData` to allow the entity to declare how to represent itself during syncing. Post entities use this to remove unsynced properties and add additional ones (like parsed `blocks`).