### PR TITLE
Move merge functions to separate utils file

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -2,22 +2,19 @@
  * External dependencies
  */
 import { capitalCase, pascalCase } from 'change-case';
-import { v4 as uuidv4 } from 'uuid';
 
 /**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { RichTextData } from '@wordpress/rich-text';
 import { parse } from '@wordpress/blocks';
 import { Y } from '@wordpress/sync';
-import * as math from 'lib0/math';
-import * as fun from 'lib0/function';
 
 /**
  * Internal dependencies
  */
+import { mergeBlocks, mergePrimitiveValue } from './utils/crdt';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
@@ -255,32 +252,6 @@ export const prePersistPostType = ( persistedRecord, edits ) => {
 	return newEdits;
 };
 
-const serialisableBlocksCache = new WeakMap();
-
-function makeBlockAttributesSerializable( attributes ) {
-	const newAttributes = { ...attributes };
-	for ( const [ key, value ] of Object.entries( attributes ) ) {
-		if ( value instanceof RichTextData ) {
-			newAttributes[ key ] = value.valueOf();
-		}
-	}
-	return newAttributes;
-}
-
-function makeBlocksSerializable( blocks ) {
-	return blocks.map( ( block ) => {
-		const { innerBlocks, attributes, ...rest } = block;
-		delete rest.validationIssues;
-		delete rest.originalContent;
-		// delete rest.isValid
-		return {
-			...rest,
-			attributes: makeBlockAttributesSerializable( attributes ),
-			innerBlocks: makeBlocksSerializable( innerBlocks ),
-		};
-	} );
-}
-
 /**
  * Returns the list of post type entities.
  *
@@ -329,179 +300,55 @@ async function loadPostTypeEntities() {
 			__unstable_rest_base: postType.rest_base,
 			syncConfig: {
 				/**
-				 * @param {Y.Doc} ydoc
-				 * @param {any}   allChanges
+				 * @param {Y.Doc}  ydoc
+				 * @param {any}    changes
+				 * @param {string} origin
 				 */
-				applyChangesToCRDTDoc: ( ydoc, allChanges ) => {
+				applyChangesToCRDTDoc: ( ydoc, changes, origin ) => {
 					// local changes happened. Apply the differences to the ydoc
 					const ycontent = ydoc.getMap( 'document' );
-					const changes = Object.fromEntries(
-						Object.entries( allChanges ).filter( ( [ key ] ) =>
-							syncedProperties.has( key )
-						)
+
+					const filteredEntries = Object.entries( changes ).filter(
+						( [ key, value ] ) =>
+							syncedProperties.has( key ) &&
+							'function' !== typeof value // cannot serialize function values
 					);
 
-					Object.entries( changes ).forEach( ( [ key, value ] ) => {
-						if ( typeof value !== 'function' ) {
-							if ( key === 'blocks' ) {
-								if ( ! serialisableBlocksCache.has( value ) ) {
-									serialisableBlocksCache.set(
-										value,
-										makeBlocksSerializable( value )
-									);
+					filteredEntries.forEach( ( [ key, newValue ] ) => {
+						const currentValue = ycontent.get( key );
+
+						// Return .get() result so that caller can operate on the data type
+						// without having to call .get() themselves.
+						function setValue( updatedValue ) {
+							ycontent.set( key, updatedValue );
+							return ycontent.get( key );
+						}
+
+						switch ( key ) {
+							case 'blocks': {
+								let currentBlocks = currentValue;
+								if ( ! ( currentBlocks instanceof Y.Array ) ) {
+									currentBlocks = setValue( new Y.Array() ); // Initialize
 								}
-								const blocks =
-									serialisableBlocksCache.get( value );
-								// This is a rudimentary diff implementation similar to the y-prosemirror diffing
-								// approach.
-								// A better implementation would also diff the textual content and represent it
-								// using a Y.Text type.
-								// However, at this time it makes more sense to keep this algorithm generic to
-								// support all kinds of block types.
-								// Ideally, we ensure that block data structure have a consistent data format.
-								// E.g.:
-								//   - textual content (using rich-text formatting?) may always be stored under `block.text`
-								//   - local information that shouldn't be shared (e.g. clientId or isDragging) is stored under `block.private`
-								if (
-									! ycontent.has( key ) ||
-									ycontent.get( key ) instanceof Array
-								) {
-									// @todo remove the array check
-									ycontent.set( key, new Y.Array() );
-								}
-								/**
-								 * @type {Y.Array<Y.Map<any>>}
-								 */
-								const yblocks = ycontent.get( key );
-								const numOfCommonEntries = math.min(
-									blocks.length,
-									yblocks.length
+
+								// Block[] from local changes or Y.Array< Y.Map > from peer.
+								const newBlocks = newValue ?? [];
+
+								// Merge blocks does not need `setValue` because it has been
+								// called above and the result can be operated on directly.
+								mergeBlocks( currentBlocks, newBlocks, origin );
+								break;
+							}
+
+							// Add support for additional data types here.
+
+							default: {
+								mergePrimitiveValue(
+									currentValue ?? undefined,
+									newValue ?? undefined,
+									setValue,
+									origin
 								);
-								let left = 0;
-								let right = 0;
-								/**
-								 * @param {any}   gblock
-								 * @param {Y.Map} yblock
-								 */
-								const blocksEqual = ( gblock, yblock ) => {
-									if ( yblock.toJSON ) {
-										yblock = yblock.toJSON();
-									}
-									// we must not sync clientId, as this can't be generated consistenctly and
-									// hence will lead to merge conflicts.
-									const overwrites = {
-										innerBlocks: null,
-										clientId: null,
-									};
-									const res = fun.equalityDeep(
-										Object.assign( {}, gblock, overwrites ),
-										Object.assign( {}, yblock, overwrites )
-									);
-									const inners = gblock.innerBlocks || [];
-									const yinners = yblock.innerBlocks || [];
-									return (
-										res &&
-										inners.length === yinners.length &&
-										inners.every( ( block, i ) =>
-											blocksEqual( block, yinners[ i ] )
-										)
-									);
-								};
-								// skip equal blocks from left
-								for (
-									;
-									left < numOfCommonEntries &&
-									blocksEqual(
-										blocks[ left ],
-										yblocks.get( left )
-									);
-									left++
-								) {
-									/* nop */
-								}
-								// skip equal blocks from right
-								for (
-									;
-									right < numOfCommonEntries - left &&
-									blocksEqual(
-										blocks[ blocks.length - right - 1 ],
-										yblocks.get(
-											yblocks.length - right - 1
-										)
-									);
-									right++
-								) {
-									/* nop */
-								}
-								const numOfUpdatesNeeded =
-									numOfCommonEntries - left - right;
-								const numOfInsertionsNeeded = math.max(
-									0,
-									blocks.length - yblocks.length
-								);
-								const numOfDeletionsNeeded = math.max(
-									0,
-									yblocks.length - blocks.length
-								);
-								// updates
-								for (
-									let i = 0;
-									i < numOfUpdatesNeeded;
-									i++, left++
-								) {
-									const block = blocks[ left ];
-									const yblock = yblocks.get( left );
-									Object.entries( block ).forEach(
-										( [ k, v ] ) => {
-											if (
-												! fun.equalityDeep(
-													block[ k ],
-													yblock.get( k )
-												)
-											) {
-												yblock.set( k, v );
-											}
-										}
-									);
-									yblock.forEach( ( _v, k ) => {
-										if ( ! block.hasOwnProperty( k ) ) {
-											yblock.delete( k );
-										}
-									} );
-								}
-								// deletes
-								yblocks.delete( left, numOfDeletionsNeeded );
-								// inserts
-								for (
-									let i = 0;
-									i < numOfInsertionsNeeded;
-									i++, left++
-								) {
-									yblocks.insert( left, [
-										new Y.Map(
-											Object.entries( blocks[ left ] )
-										),
-									] );
-								}
-								const knownClientIds = new Set();
-								// remove duplicate clientids
-								for ( let j = 0; j < yblocks.length; j++ ) {
-									const yblock = yblocks.get( j );
-									if (
-										knownClientIds.has(
-											yblock.get( 'clientId' )
-										)
-									) {
-										yblock.set( 'clientId', uuidv4() );
-									}
-									knownClientIds.add(
-										yblock.get( 'clientId' )
-									);
-								}
-							} else if (
-								! fun.equalityDeep( ycontent.get( key ), value )
-							) {
-								ycontent.set( key, value );
 							}
 						}
 					} );

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -23,7 +23,11 @@ interface Block {
 	validationIssues?: string[]; // unserializable
 }
 
-type Foo = Y.Map< Block[ keyof Block ] >;
+// The Y.Map type is not easy to work with. The generic type it accepts represents
+// the possible values of the map, which are varied in our case. This type is
+// accurate, but will require aggressive type narrowing when the map values are
+// accessed -- or type casting with `as`.
+type YBlock = Y.Map< Block[ keyof Block ] >;
 
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
@@ -39,8 +43,10 @@ function makeBlockAttributesSerializable(
 	return newAttributes;
 }
 
-function makeBlocksSerializable( blocks: Block[] | Y.Array< Foo > ): Block[] {
-	return blocks.map( ( block: Block | Foo ) => {
+function makeBlocksSerializable(
+	blocks: Block[] | Y.Array< YBlock >
+): Block[] {
+	return blocks.map( ( block: Block | YBlock ) => {
 		const blockAsJson = block instanceof Y.Map ? block.toJSON() : block;
 		const { innerBlocks, attributes, ...rest } = blockAsJson;
 		delete rest.validationIssues;
@@ -58,7 +64,7 @@ function makeBlocksSerializable( blocks: Block[] | Y.Array< Foo > ): Block[] {
  * @param {any}   gblock
  * @param {Y.Map} yblock
  */
-function areBlocksEqual( gblock: Block, yblock: Foo ): boolean {
+function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 	const yblockAsJson = yblock.toJSON();
 
 	// we must not sync clientId, as this can't be generated consistenctly and
@@ -83,8 +89,8 @@ function areBlocksEqual( gblock: Block, yblock: Foo ): boolean {
 }
 
 export function mergeBlocks(
-	yblocks: Y.Array< Foo >,
-	newValue: Block[] | Y.Array< Foo >,
+	yblocks: Y.Array< YBlock >,
+	newValue: Block[] | Y.Array< YBlock >,
 	_origin: string // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void {
 	// Ensure we are working with serializable block data.

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -1,0 +1,183 @@
+/**
+ * External dependencies
+ */
+import { v4 as uuidv4 } from 'uuid';
+import * as math from 'lib0/math';
+import * as fun from 'lib0/function';
+
+/**
+ * WordPress dependencies
+ */
+import { RichTextData } from '@wordpress/rich-text';
+import { Y } from '@wordpress/sync';
+
+interface BlockAttributes {
+	[ key: string ]: unknown;
+}
+
+interface Block {
+	attributes: BlockAttributes;
+	clientId?: string;
+	innerBlocks: Block[];
+	originalContent?: string; // unserializable
+	validationIssues?: string[]; // unserializable
+}
+
+type Foo = Y.Map< Block[ keyof Block ] >;
+
+const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
+
+function makeBlockAttributesSerializable(
+	attributes: BlockAttributes
+): BlockAttributes {
+	const newAttributes = { ...attributes };
+	for ( const [ key, value ] of Object.entries( attributes ) ) {
+		if ( value instanceof RichTextData ) {
+			newAttributes[ key ] = value.valueOf();
+		}
+	}
+	return newAttributes;
+}
+
+function makeBlocksSerializable( blocks: Block[] | Y.Array< Foo > ): Block[] {
+	return blocks.map( ( block: Block | Foo ) => {
+		const blockAsJson = block instanceof Y.Map ? block.toJSON() : block;
+		const { innerBlocks, attributes, ...rest } = blockAsJson;
+		delete rest.validationIssues;
+		delete rest.originalContent;
+		// delete rest.isValid
+		return {
+			...rest,
+			attributes: makeBlockAttributesSerializable( attributes ),
+			innerBlocks: makeBlocksSerializable( innerBlocks ),
+		};
+	} );
+}
+
+/**
+ * @param {any}   gblock
+ * @param {Y.Map} yblock
+ */
+function areBlocksEqual( gblock: Block, yblock: Foo ): boolean {
+	const yblockAsJson = yblock.toJSON();
+
+	// we must not sync clientId, as this can't be generated consistenctly and
+	// hence will lead to merge conflicts.
+	const overwrites = {
+		innerBlocks: null,
+		clientId: null,
+	};
+	const res = fun.equalityDeep(
+		Object.assign( {}, gblock, overwrites ),
+		Object.assign( {}, yblock, overwrites )
+	);
+	const inners = gblock.innerBlocks || [];
+	const yinners = yblockAsJson.innerBlocks || [];
+	return (
+		res &&
+		inners.length === yinners.length &&
+		inners.every( ( block: Block, i: number ) =>
+			areBlocksEqual( block, yinners[ i ] )
+		)
+	);
+}
+
+export function mergeBlocks(
+	yblocks: Y.Array< Foo >,
+	newValue: Block[] | Y.Array< Foo >,
+	_origin: string // eslint-disable-line @typescript-eslint/no-unused-vars
+): void {
+	// Ensure we are working with serializable block data.
+	if ( ! serializableBlocksCache.has( newValue ) ) {
+		serializableBlocksCache.set(
+			newValue,
+			makeBlocksSerializable( newValue )
+		);
+	}
+	const blocks = serializableBlocksCache.get( newValue ) ?? [];
+
+	// This is a rudimentary diff implementation similar to the y-prosemirror diffing
+	// approach.
+	// A better implementation would also diff the textual content and represent it
+	// using a Y.Text type.
+	// However, at this time it makes more sense to keep this algorithm generic to
+	// support all kinds of block types.
+	// Ideally, we ensure that block data structure have a consistent data format.
+	// E.g.:
+	//   - textual content (using rich-text formatting?) may always be stored under `block.text`
+	//   - local information that shouldn't be shared (e.g. clientId or isDragging) is stored under `block.private`
+
+	const numOfCommonEntries = math.min( blocks.length ?? 0, yblocks.length );
+
+	let left = 0;
+	let right = 0;
+
+	// skip equal blocks from left
+	for (
+		;
+		left < numOfCommonEntries &&
+		areBlocksEqual( blocks[ left ], yblocks.get( left ) );
+		left++
+	) {
+		/* nop */
+	}
+
+	// skip equal blocks from right
+	for (
+		;
+		right < numOfCommonEntries - left &&
+		areBlocksEqual(
+			blocks[ blocks.length - right - 1 ],
+			yblocks.get( yblocks.length - right - 1 )
+		);
+		right++
+	) {
+		/* nop */
+	}
+
+	const numOfUpdatesNeeded = numOfCommonEntries - left - right;
+	const numOfInsertionsNeeded = math.max( 0, blocks.length - yblocks.length );
+	const numOfDeletionsNeeded = math.max( 0, yblocks.length - blocks.length );
+
+	// updates
+	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
+		const block = blocks[ left ];
+		const yblock = yblocks.get( left );
+		Object.entries( block ).forEach( ( [ k, v ] ) => {
+			if ( ! fun.equalityDeep( block[ k ], yblock.get( k ) ) ) {
+				yblock.set( k, v );
+			}
+		} );
+		yblock.forEach( ( _v, k ) => {
+			if ( ! block.hasOwnProperty( k ) ) {
+				yblock.delete( k );
+			}
+		} );
+	}
+
+	// deletes
+	yblocks.delete( left, numOfDeletionsNeeded );
+
+	// inserts
+	for ( let i = 0; i < numOfInsertionsNeeded; i++, left++ ) {
+		yblocks.insert( left, [
+			new Y.Map< Block[ keyof Block ] >(
+				Object.entries( blocks[ left ] )
+			),
+		] );
+	}
+
+	// remove duplicate clientids
+	const knownClientIds = new Set< string >();
+	for ( let j = 0; j < yblocks.length; j++ ) {
+		const yblock: Y.Map< Block[ keyof Block ] > = yblocks.get( j );
+
+		let clientId: string = yblock.get( 'clientId' ) as string;
+
+		if ( knownClientIds.has( clientId ) ) {
+			clientId = uuidv4();
+			yblock.set( 'clientId', clientId );
+		}
+		knownClientIds.add( clientId );
+	}
+}

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import * as fun from 'lib0/function';
+
+export { mergeBlocks } from './crdt-blocks';
+
+export type SetValueFunction< ValueType = unknown > = (
+	value: ValueType
+) => ValueType;
+
+export function mergePrimitiveValue< ValueType = unknown >(
+	currentValue: ValueType,
+	newValue: ValueType,
+	setValue: SetValueFunction< ValueType >,
+	_origin: string // eslint-disable-line @typescript-eslint/no-unused-vars
+): void {
+	if ( ! fun.equalityDeep( currentValue, newValue ) ) {
+		setValue( newValue );
+	}
+}

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -187,7 +187,11 @@ export class SyncProvider {
 		const initialStateDoc = new Y.Doc( { meta: new Map() } );
 
 		const initialData = syncConfig.getInitialObjectData( record );
-		syncConfig.applyChangesToCRDTDoc( initialStateDoc, initialData );
+		syncConfig.applyChangesToCRDTDoc(
+			initialStateDoc,
+			initialData,
+			'syncProvider.getInitialCRDTDoc'
+		);
 
 		return initialStateDoc;
 	}
@@ -222,10 +226,10 @@ export class SyncProvider {
 			return;
 		}
 
-		const entityState = this.getEntityState( objectType, objectId );
+		const ydoc = this.getEntityState( objectType, objectId )?.ydoc;
 
-		entityState?.ydoc.transact( () => {
-			syncConfig.applyChangesToCRDTDoc( entityState.ydoc, changes );
+		ydoc?.transact( () => {
+			syncConfig.applyChangesToCRDTDoc( ydoc, changes, origin );
 		}, origin );
 	}
 

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -25,7 +25,11 @@ export type ConnectDoc = (
 ) => Promise< ConnectDocResult >;
 
 export type SyncConfig = {
-	applyChangesToCRDTDoc: ( ydoc: Y.Doc, data: Partial< ObjectData > ) => void;
+	applyChangesToCRDTDoc: (
+		ydoc: Y.Doc,
+		data: Partial< ObjectData >,
+		origin: string
+	) => void;
 	fromCRDTDoc: ( ydoc: Y.Doc ) => ObjectData;
 	getInitialObjectData: ( record: ObjectData ) => ObjectData;
 	getObjectId: ( data: ObjectData ) => ObjectID;


### PR DESCRIPTION
- Move sync merge functions to separate utils file, where they are easier to read, understand, and unit test
- Convert to TypeScript
- Pass in `origin` so that it can used to vary behavior based on whether it is a local change (`'gutenberg'`) or applied from a remote peer.