### PR TITLE
Add post type support for collaborative editing

### DIFF
--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -22,3 +22,20 @@ function gutenberg_rest_api_init_collaborative_editing() {
 	wp_add_inline_script( 'wp-sync', 'window.__experimentalCollaborativeEditingSecret = "' . $collaborative_editing_secret . '";', 'before' );
 }
 add_action( 'admin_init', 'gutenberg_rest_api_init_collaborative_editing' );
+
+/**
+ * Add support for collaborative editing to a some built-in post types.
+ */
+function gutenberg_add_collaborative_editing_post_type_support() {
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	if ( ! $gutenberg_experiments || ! array_key_exists( 'gutenberg-sync-collaboration', $gutenberg_experiments ) ) {
+		return;
+	}
+
+	foreach ( array( 'page', 'post' ) as $post_type ) {
+		if ( post_type_exists( $post_type ) ) {
+			add_post_type_support( $post_type, 'collaborative-editing' );
+		}
+	}
+}
+add_action( 'init', 'gutenberg_add_collaborative_editing_post_type_support', 10, 0 );

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -267,7 +267,7 @@ async function loadPostTypeEntities() {
 	] );
 
 	const postTypes = await apiFetch( {
-		path: '/wp/v2/types?context=view',
+		path: '/wp/v2/types?context=edit',
 	} );
 	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
@@ -295,6 +295,9 @@ async function loadPostTypeEntities() {
 			__unstablePrePersist: isTemplate ? undefined : prePersistPostType,
 			__unstable_rest_base: postType.rest_base,
 			syncConfig: {
+				enabled: Boolean(
+					postType.supports?.[ 'collaborative-editing' ]
+				),
 				/**
 				 * @param {Y.Doc}  ydoc
 				 * @param {Object} changes
@@ -338,7 +341,7 @@ async function loadPostTypeEntities() {
 					);
 				},
 				getObjectId: ( { id } ) => id,
-				objectType: 'postType/' + postType.name,
+				objectType: `postType/${ postType.slug }`,
 				supportsAwareness: true,
 				supportsUndo: true,
 			},

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -9,12 +9,11 @@ import { capitalCase, pascalCase } from 'change-case';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
-import { Y } from '@wordpress/sync';
 
 /**
  * Internal dependencies
  */
-import { mergeBlocks, mergePrimitiveValue } from './utils/crdt';
+import { defaultApplyChangesToCRDTDoc } from './utils/crdt';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
@@ -298,77 +297,23 @@ async function loadPostTypeEntities() {
 			syncConfig: {
 				/**
 				 * @param {Y.Doc}  ydoc
-				 * @param {any}    changes
+				 * @param {Object} changes
 				 * @param {string} origin
 				 */
 				applyChangesToCRDTDoc: ( ydoc, changes, origin ) => {
-					// local changes happened. Apply the differences to the ydoc
-					const ycontent = ydoc.getMap( 'document' );
-
-					const filteredEntries = Object.entries( changes ).filter(
-						( [ key, value ] ) =>
-							syncedProperties.has( key ) &&
-							'function' !== typeof value // cannot serialize function values
+					const filteredChanges = Object.fromEntries(
+						Object.entries( changes ).filter(
+							( [ key, value ] ) =>
+								syncedProperties.has( key ) &&
+								'function' !== typeof value // cannot serialize function values
+						)
 					);
 
-					filteredEntries.forEach( ( [ key, newValue ] ) => {
-						const currentValue = ycontent.get( key );
-
-						// Return .get() result so that caller can operate on the data type
-						// without having to call .get() themselves.
-						function setValue( updatedValue ) {
-							ycontent.set( key, updatedValue );
-							return ycontent.get( key );
-						}
-
-						// Set primitive a value (strings, numbers, booleans).
-						function setPrimitiveValue( primitiveValue ) {
-							mergePrimitiveValue(
-								currentValue ?? undefined,
-								primitiveValue ?? undefined,
-								setValue,
-								origin
-							);
-						}
-
-						switch ( key ) {
-							case 'blocks': {
-								let currentBlocks = currentValue;
-								if ( ! ( currentBlocks instanceof Y.Array ) ) {
-									currentBlocks = setValue( new Y.Array() ); // Initialize
-								}
-
-								// Block[] from local changes or Y.Array< Y.Map > from peer.
-								const newBlocks = newValue ?? [];
-
-								// Merge blocks does not need `setValue` because it has been
-								// called above and the result can be operated on directly.
-								mergeBlocks( currentBlocks, newBlocks, origin );
-								break;
-							}
-
-							case 'title': {
-								// Copy logic from prePersistPostType to ensure that the "Auto
-								// Draft" template title is not synced.
-								let rawNewValue = newValue?.raw ?? newValue;
-								if (
-									! currentValue &&
-									'Auto Draft' === rawNewValue
-								) {
-									rawNewValue = '';
-								}
-
-								setPrimitiveValue( rawNewValue );
-								break;
-							}
-
-							// Add support for additional data types here.
-
-							default: {
-								setPrimitiveValue( newValue );
-							}
-						}
-					} );
+					defaultApplyChangesToCRDTDoc(
+						ydoc,
+						filteredChanges,
+						origin
+					);
 				},
 				fromCRDTDoc: defaultFromCRDTDoc,
 				/**

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -296,7 +296,8 @@ async function loadPostTypeEntities() {
 			__unstable_rest_base: postType.rest_base,
 			syncConfig: {
 				enabled: Boolean(
-					postType.supports?.[ 'collaborative-editing' ]
+					postType.supports?.[ 'collaborative-editing' ] &&
+						postType.supports?.editor
 				),
 				/**
 				 * @param {Y.Doc}  ydoc

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -149,7 +149,7 @@ export const getEntityRecord =
 
 			if (
 				window.__experimentalEnableSync &&
-				entityConfig.syncConfig &&
+				entityConfig.syncConfig?.enabled &&
 				! query
 			) {
 				if ( globalThis.IS_GUTENBERG_PLUGIN ) {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -15,7 +15,7 @@ interface BlockAttributes {
 	[ key: string ]: unknown;
 }
 
-interface Block {
+export interface Block {
 	attributes: BlockAttributes;
 	clientId?: string;
 	innerBlocks: Block[];
@@ -27,7 +27,7 @@ interface Block {
 // the possible values of the map, which are varied in our case. This type is
 // accurate, but will require aggressive type narrowing when the map values are
 // accessed -- or type casting with `as`.
-type YBlock = Y.Map< Block[ keyof Block ] >;
+export type YBlock = Y.Map< Block[ keyof Block ] >;
 
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -3,17 +3,89 @@
  */
 import * as fun from 'lib0/function';
 
-export { mergeBlocks } from './crdt-blocks';
+/**
+ * WordPress dependencies
+ */
+import { type CRDTDoc, Y } from '@wordpress/sync';
 
-export type SetValueFunction< ValueType = unknown > = (
-	value: ValueType
-) => ValueType;
+/**
+ * Internal dependencies
+ */
+import { mergeBlocks, type Block, type YBlock } from './crdt-blocks';
 
-export function mergePrimitiveValue< ValueType = unknown >(
+type PrimitiveValue = string | number | boolean | null | undefined;
+
+interface PostChanges {
+	blocks?: Y.Array< YBlock > | Block[];
+	title?: string | { raw: string };
+}
+
+export function defaultApplyChangesToCRDTDoc(
+	ydoc: CRDTDoc,
+	changes: PostChanges,
+	origin: string
+): void {
+	const ymap = ydoc.getMap( 'document' );
+
+	Object.entries( changes ).forEach( ( [ key, newValue ] ) => {
+		// Return .get() result so that caller can operate on the data type
+		// without having to call .get() themselves.
+		function setValue< T = unknown >( updatedValue: T ): T {
+			ymap.set( key, updatedValue );
+			return ymap.get( key ) as T;
+		}
+
+		switch ( key ) {
+			case 'blocks': {
+				let currentBlocks = ymap.get(
+					'blocks'
+				) as PostChanges[ 'blocks' ];
+
+				if ( ! ( currentBlocks instanceof Y.Array ) ) {
+					currentBlocks = setValue< Y.Array< YBlock > >(
+						new Y.Array()
+					); // Initialize
+				}
+
+				// Block[] from local changes or Y.Array< Y.Map > from peer.
+				const newBlocks = newValue ?? [];
+
+				// Merge blocks does not need `setValue` because it has been
+				// called above and the result can be operated on directly.
+				mergeBlocks( currentBlocks, newBlocks, origin );
+				break;
+			}
+
+			case 'title': {
+				const currentValue = ymap.get(
+					'title'
+				) as PostChanges[ 'title' ];
+
+				// Copy logic from prePersistPostType to ensure that the "Auto
+				// Draft" template title is not synced.
+				let rawNewValue = newValue?.raw ?? newValue;
+				if ( ! currentValue && 'Auto Draft' === rawNewValue ) {
+					rawNewValue = '';
+				}
+
+				mergePrimitiveValue( currentValue, rawNewValue, setValue );
+				break;
+			}
+
+			// Add support for additional data types here.
+
+			default: {
+				const currentValue = ymap.get( key );
+				mergePrimitiveValue( currentValue, newValue, setValue );
+			}
+		}
+	} );
+}
+
+export function mergePrimitiveValue< ValueType extends PrimitiveValue >(
 	currentValue: ValueType,
 	newValue: ValueType,
-	setValue: SetValueFunction< ValueType >,
-	_origin: string // eslint-disable-line @typescript-eslint/no-unused-vars
+	setValue: ( value: ValueType ) => ValueType
 ): void {
 	if ( ! fun.equalityDeep( currentValue, newValue ) ) {
 		setValue( newValue );


### PR DESCRIPTION
This introduces a declarative mechanism for enabling collaborative editing for a post type via post type supports:

```php
add_post_type_support( 'my_custom_post_type', 'collaborative-editing' );
```

By default, it is supported for `post` and `page`.

This also reorganizes `applyChangesToCRDTDoc` into a utility file and converts it to TypeScript.