### PR TITLE
Improve/yjs document types

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -18,6 +18,11 @@ interface BlockAttributes {
 	[ key: string ]: unknown;
 }
 
+interface BlockType {
+	name: string;
+	attributes?: Record< string, { type?: string } >;
+}
+
 export interface Block {
 	attributes: BlockAttributes;
 	clientId?: string;
@@ -104,10 +109,39 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 	);
 }
 
+function createNewYAttributeMap(
+	blockName: string,
+	attributes: BlockAttributes
+): Y.Map< Y.Text | unknown > {
+	return new Y.Map(
+		Object.entries( attributes ).map(
+			( [ attributeKey, attributeValue ] ) => {
+				const isRichText = isRichTextAttribute(
+					blockName,
+					attributeKey
+				);
+
+				if ( isRichText && 'string' === typeof attributeValue ) {
+					return [
+						attributeKey,
+						new Y.Text( attributeValue as string ),
+					];
+				}
+
+				return [ attributeKey, attributeValue ];
+			}
+		)
+	);
+}
+
 function createNewYBlock( block: Block ): YBlock {
 	return new Y.Map(
 		Object.entries( block ).map( ( [ key, value ] ) => {
 			switch ( key ) {
+				case 'attributes': {
+					return [ key, createNewYAttributeMap( block.name, value ) ];
+				}
+
 				case 'innerBlocks': {
 					const innerBlocks = new Y.Array();
 
@@ -124,30 +158,6 @@ function createNewYBlock( block: Block ): YBlock {
 					);
 
 					return [ key, innerBlocks ];
-				}
-
-				case 'attributes': {
-					const attributes = new Y.Map(
-						Object.entries( value ).map(
-							( [ attributeKey, attributeValue ] ) => {
-								const isRichText = isRichTextAttribute(
-									block.name,
-									attributeKey
-								);
-
-								if ( isRichText ) {
-									return [
-										attributeKey,
-										new Y.Text( attributeValue as string ),
-									];
-								}
-
-								return [ attributeKey, attributeValue ];
-							}
-						)
-					);
-
-					return [ key, attributes ];
 				}
 
 				default:
@@ -241,32 +251,22 @@ export function mergeCrdtBlocks(
 		const yblock = yblocks.get( left );
 		Object.entries( block ).forEach( ( [ key, value ] ) => {
 			switch ( key ) {
+				case 'attributes': {
+					if (
+						! fun.equalityDeep( block[ key ], yblock.get( key ) )
+					) {
+						yblock.set(
+							key,
+							createNewYAttributeMap( block.name, value )
+						);
+					}
+					break;
+				}
+
 				case 'innerBlocks': {
 					// Recursively merge innerBlocks
 					const yInnerBlocks = yblock.get( key ) as Y.Array< YBlock >;
 					mergeCrdtBlocks( yInnerBlocks, value ?? [], _origin );
-					break;
-				}
-
-				case 'attributes': {
-					const yAttributes = yblock.get( key ) as Y.Map< unknown >;
-					Object.entries( value ).forEach(
-						( [ attributeKey, attributeValue ] ) => {
-							const isRichText = isRichTextAttribute(
-								block.name,
-								attributeKey
-							);
-
-							if ( isRichText ) {
-								const ytext = new Y.Text(
-									attributeValue as string
-								);
-								yAttributes.set( attributeKey, ytext );
-							} else {
-								yAttributes.set( attributeKey, attributeValue );
-							}
-						}
-					);
 					break;
 				}
 
@@ -336,47 +336,43 @@ function shouldBlockBeSynced( block: Block ): boolean {
 	return true;
 }
 
-// Cache rich-text attributes for looked-up block types.
-const cachedRichTextAttributes = new Map< string, Map< string, true > >();
+// Cache rich-text attributes for all block types.
+let cachedRichTextAttributes: Map< string, Map< string, true > >;
 
 /**
  * Given a block name and attribute key, return true if the attribute is rich-text typed.
  *
- * @param blockName    The name of the block, e.g. 'core/paragraph'.
- * @param attributeKey The key of the attribute to check, e.g. 'content'.
+ * @param blockName     The name of the block, e.g. 'core/paragraph'.
+ * @param attributeName The name of the attribute to check, e.g. 'content'.
  * @return True if the attribute is rich-text typed, false otherwise.
  */
 function isRichTextAttribute(
 	blockName: string,
-	attributeKey: string
+	attributeName: string
 ): boolean {
-	if ( cachedRichTextAttributes.has( blockName ) ) {
-		// If we've already cached the rich-text attributes for this block type,
-		// return the cached value.
-		return (
-			cachedRichTextAttributes.get( blockName )?.has( attributeKey ) ??
-			false
-		);
-	}
+	if ( ! cachedRichTextAttributes ) {
+		// Parse the attributes for all blocks once.
+		cachedRichTextAttributes = new Map< string, Map< string, true > >();
 
-	const allRegisteredBlockTypes = getBlockTypes();
-	const matchingBlockType = allRegisteredBlockTypes.find(
-		( blockType ) => blockType.name === blockName
-	);
+		for ( const blockType of getBlockTypes() as BlockType[] ) {
+			const richTextAttributeMap = new Map< string, true >();
 
-	const isBlockTypeRegistered = matchingBlockType !== undefined;
-	const richTextAttributeMap = new Map< string, true >();
-
-	if ( isBlockTypeRegistered ) {
-		for ( const [ registeredKey, registeredProperties ] of Object.entries(
-			matchingBlockType.attributes as Record< string, { type: string } >
-		) ) {
-			if ( registeredProperties.type === 'rich-text' ) {
-				richTextAttributeMap.set( registeredKey, true );
+			for ( const [ name, definition ] of Object.entries(
+				blockType.attributes ?? {}
+			) ) {
+				if ( 'rich-text' === definition.type ) {
+					richTextAttributeMap.set( name, true );
+				}
 			}
+
+			cachedRichTextAttributes.set(
+				blockType.name,
+				richTextAttributeMap
+			);
 		}
 	}
 
-	cachedRichTextAttributes.set( blockName, richTextAttributeMap );
-	return richTextAttributeMap.has( attributeKey );
+	return (
+		cachedRichTextAttributes.get( blockName )?.has( attributeName ) ?? false
+	);
 }

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -122,6 +122,19 @@ function createNewYBlock( block: Block ): YBlock {
 					return [ key, value ];
 				}
 
+				case 'attributes': {
+					const attributes = new Y.Map(
+						Object.entries( value ).map(
+							( [ attributeKey, attributeValue ] ) => {
+								// Rich-text logic here
+								return [ attributeKey, attributeValue ];
+							}
+						)
+					);
+
+					return [ key, attributes ];
+				}
+
 				default:
 					return [ key, value ];
 			}
@@ -217,6 +230,17 @@ export function mergeCrdtBlocks(
 					// Recursively merge innerBlocks
 					const yInnerBlocks = yblock.get( key ) as Y.Array< YBlock >;
 					mergeCrdtBlocks( yInnerBlocks, value ?? [], _origin );
+					break;
+				}
+
+				case 'attributes': {
+					const yAttributes = yblock.get( key ) as Y.Map< unknown >;
+					Object.entries( value ).forEach(
+						( [ attributeKey, attributeValue ] ) => {
+							// Rich-text logic here
+							yAttributes.set( attributeKey, attributeValue );
+						}
+					);
 					break;
 				}
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -137,7 +137,6 @@ function createNewYBlock( block: Block ): YBlock {
  * @param incomingBlocks Gutenberg blocks being synced.
  * @param _origin        The origin of the sync, either 'syncProvider.getInitialCRDTDoc' or 'gutenberg'.
  */
-
 export function mergeCrdtBlocks(
 	yblocks: Y.Array< YBlock >, // yblocks represent the blocks in the local Y.Doc
 	incomingBlocks: Block[], // incomingBlocks represent JSON blocks being synced, either from a peer or from the local editor
@@ -212,16 +211,21 @@ export function mergeCrdtBlocks(
 	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
 		const block = blocksToSync[ left ];
 		const yblock = yblocks.get( left );
-		Object.entries( block ).forEach( ( [ k, v ] ) => {
-			if ( ! fun.equalityDeep( block[ k ], yblock.get( k ) ) ) {
-				if ( k === 'innerBlocks' ) {
+		Object.entries( block ).forEach( ( [ key, value ] ) => {
+			switch ( key ) {
+				case 'innerBlocks': {
 					// Recursively merge innerBlocks
-					const yInnerBlocks = yblock.get( k ) as Y.Array< YBlock >;
-
-					mergeCrdtBlocks( yInnerBlocks, v, _origin );
+					const yInnerBlocks = yblock.get( key ) as Y.Array< YBlock >;
+					mergeCrdtBlocks( yInnerBlocks, value ?? [], _origin );
+					break;
 				}
 
-				yblock.set( k, v );
+				default:
+					if (
+						! fun.equalityDeep( block[ key ], yblock.get( key ) )
+					) {
+						yblock.set( key, value );
+					}
 			}
 		} );
 		yblock.forEach( ( _v, k ) => {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -24,11 +24,22 @@ export interface Block {
 	name: string;
 }
 
+export type YBlock = Y.Map<
+	/* name, clientId, and originalContent are strings. */
+	| string
+	/* validationIssues? is an array of strings. */
+	| string[]
+	/* attributes is a Y.Map< unknown >. */
+	| Y.Map< unknown >
+	/* innerBlocks is a Y.Array< YBlock >. */
+	| Y.Array< YBlock >
+>;
+
 // The Y.Map type is not easy to work with. The generic type it accepts represents
 // the possible values of the map, which are varied in our case. This type is
 // accurate, but will require aggressive type narrowing when the map values are
 // accessed -- or type casting with `as`.
-export type YBlock = Y.Map< Block[ keyof Block ] >;
+// export type YBlock = Y.Map< Block[ keyof Block ] >;
 
 const serializableBlocksCache = new WeakMap< WeakKey, Block[] >();
 
@@ -90,22 +101,31 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 	);
 }
 
+/**
+ * Merge incoming block data into the local Y.Doc.
+ * This function is called to sync local block changes to a shared Y.Doc.
+ *
+ * @param yblocks        The blocks in the local Y.Doc.
+ * @param incomingBlocks Gutenberg blocks being synced.
+ * @param _origin        The origin of the sync, either 'syncProvider.getInitialCRDTDoc' or 'gutenberg'.
+ */
+
 export function mergeCrdtBlocks(
-	yblocks: Y.Array< YBlock >,
-	newValue: Block[] | Y.Array< YBlock >,
+	yblocks: Y.Array< YBlock >, // yblocks represent the blocks in the local Y.Doc
+	incomingBlocks: Block[], // incomingBlocks represent JSON blocks being synced, either from a peer or from the local editor
 	_origin: string // eslint-disable-line @typescript-eslint/no-unused-vars
 ): void {
 	// Ensure we are working with serializable block data.
-	if ( ! serializableBlocksCache.has( newValue ) ) {
+	if ( ! serializableBlocksCache.has( incomingBlocks ) ) {
 		serializableBlocksCache.set(
-			newValue,
-			makeBlocksSerializable( newValue )
+			incomingBlocks,
+			makeBlocksSerializable( incomingBlocks )
 		);
 	}
-	const unfilteredBlocks = serializableBlocksCache.get( newValue ) ?? [];
+	const allBlocks = serializableBlocksCache.get( incomingBlocks ) ?? [];
 
 	// Ensure we skip blocks that we don't want to sync at the moment
-	const blocks = unfilteredBlocks.filter( ( block ) =>
+	const blocksToSync = allBlocks.filter( ( block ) =>
 		shouldBlockBeSynced( block )
 	);
 
@@ -119,8 +139,10 @@ export function mergeCrdtBlocks(
 	// E.g.:
 	//   - textual content (using rich-text formatting?) may always be stored under `block.text`
 	//   - local information that shouldn't be shared (e.g. clientId or isDragging) is stored under `block.private`
-
-	const numOfCommonEntries = math.min( blocks.length ?? 0, yblocks.length );
+	const numOfCommonEntries = math.min(
+		blocksToSync.length ?? 0,
+		yblocks.length
+	);
 
 	let left = 0;
 	let right = 0;
@@ -129,7 +151,7 @@ export function mergeCrdtBlocks(
 	for (
 		;
 		left < numOfCommonEntries &&
-		areBlocksEqual( blocks[ left ], yblocks.get( left ) );
+		areBlocksEqual( blocksToSync[ left ], yblocks.get( left ) );
 		left++
 	) {
 		/* nop */
@@ -140,7 +162,7 @@ export function mergeCrdtBlocks(
 		;
 		right < numOfCommonEntries - left &&
 		areBlocksEqual(
-			blocks[ blocks.length - right - 1 ],
+			blocksToSync[ blocksToSync.length - right - 1 ],
 			yblocks.get( yblocks.length - right - 1 )
 		);
 		right++
@@ -149,15 +171,28 @@ export function mergeCrdtBlocks(
 	}
 
 	const numOfUpdatesNeeded = numOfCommonEntries - left - right;
-	const numOfInsertionsNeeded = math.max( 0, blocks.length - yblocks.length );
-	const numOfDeletionsNeeded = math.max( 0, yblocks.length - blocks.length );
+	const numOfInsertionsNeeded = math.max(
+		0,
+		blocksToSync.length - yblocks.length
+	);
+	const numOfDeletionsNeeded = math.max(
+		0,
+		yblocks.length - blocksToSync.length
+	);
 
 	// updates
 	for ( let i = 0; i < numOfUpdatesNeeded; i++, left++ ) {
-		const block = blocks[ left ];
+		const block = blocksToSync[ left ];
 		const yblock = yblocks.get( left );
 		Object.entries( block ).forEach( ( [ k, v ] ) => {
 			if ( ! fun.equalityDeep( block[ k ], yblock.get( k ) ) ) {
+				if ( k === 'innerBlocks' ) {
+					// Recursively merge innerBlocks
+					const yInnerBlocks = yblock.get( k ) as Y.Array< YBlock >;
+
+					mergeCrdtBlocks( yInnerBlocks, v, _origin );
+				}
+
 				yblock.set( k, v );
 			}
 		} );
@@ -173,17 +208,17 @@ export function mergeCrdtBlocks(
 
 	// inserts
 	for ( let i = 0; i < numOfInsertionsNeeded; i++, left++ ) {
-		yblocks.insert( left, [
-			new Y.Map< Block[ keyof Block ] >(
-				Object.entries( blocks[ left ] )
-			),
-		] );
+		const newBlock = [
+			new Y.Map( Object.entries( blocksToSync[ left ] ) ) as YBlock,
+		];
+
+		yblocks.insert( left, newBlock );
 	}
 
 	// remove duplicate clientids
 	const knownClientIds = new Set< string >();
 	for ( let j = 0; j < yblocks.length; j++ ) {
-		const yblock: Y.Map< Block[ keyof Block ] > = yblocks.get( j );
+		const yblock: YBlock = yblocks.get( j );
 
 		let clientId: string = yblock.get( 'clientId' ) as string;
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -106,20 +106,21 @@ function createNewYBlock( block: Block ): YBlock {
 		Object.entries( block ).map( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'innerBlocks': {
-					if ( Array.isArray( value ) ) {
-						const innerBlocks = new Y.Array();
+					const innerBlocks = new Y.Array();
 
-						innerBlocks.insert(
-							0,
-							value.map( ( innerBlock: Block ) =>
-								createNewYBlock( innerBlock )
-							)
-						);
-
+					// If not an array, set to empty Y.Array.
+					if ( ! Array.isArray( value ) ) {
 						return [ key, innerBlocks ];
 					}
 
-					return [ key, value ];
+					innerBlocks.insert(
+						0,
+						value.map( ( innerBlock: Block ) =>
+							createNewYBlock( innerBlock )
+						)
+					);
+
+					return [ key, innerBlocks ];
 				}
 
 				case 'attributes': {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -88,7 +88,7 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 	};
 	const res = fun.equalityDeep(
 		Object.assign( {}, gblock, overwrites ),
-		Object.assign( {}, yblock, overwrites )
+		Object.assign( {}, yblockAsJson, overwrites )
 	);
 	const inners = gblock.innerBlocks || [];
 	const yinners = yblockAsJson.innerBlocks || [];

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -91,12 +91,12 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 		Object.assign( {}, yblockAsJson, overwrites )
 	);
 	const inners = gblock.innerBlocks || [];
-	const yinners = yblockAsJson.innerBlocks || [];
+	const yinners = yblock.get( 'innerBlocks' ) as Y.Array< YBlock >;
 	return (
 		res &&
 		inners.length === yinners.length &&
 		inners.every( ( block: Block, i: number ) =>
-			areBlocksEqual( block, yinners[ i ] )
+			areBlocksEqual( block, yinners.get( i ) )
 		)
 	);
 }

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -101,6 +101,34 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 	);
 }
 
+function createNewYBlock( block: Block ): YBlock {
+	return new Y.Map(
+		Object.entries( block ).map( ( [ key, value ] ) => {
+			switch ( key ) {
+				case 'innerBlocks': {
+					if ( Array.isArray( value ) ) {
+						const innerBlocks = new Y.Array();
+
+						innerBlocks.insert(
+							0,
+							value.map( ( innerBlock: Block ) =>
+								createNewYBlock( innerBlock )
+							)
+						);
+
+						return [ key, innerBlocks ];
+					}
+
+					return [ key, value ];
+				}
+
+				default:
+					return [ key, value ];
+			}
+		} )
+	);
+}
+
 /**
  * Merge incoming block data into the local Y.Doc.
  * This function is called to sync local block changes to a shared Y.Doc.
@@ -208,9 +236,7 @@ export function mergeCrdtBlocks(
 
 	// inserts
 	for ( let i = 0; i < numOfInsertionsNeeded; i++, left++ ) {
-		const newBlock = [
-			new Y.Map( Object.entries( blocksToSync[ left ] ) ) as YBlock,
-		];
+		const newBlock = [ createNewYBlock( blocksToSync[ left ] ) ];
 
 		yblocks.insert( left, newBlock );
 	}

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -11,6 +11,9 @@ import * as fun from 'lib0/function';
 import { RichTextData } from '@wordpress/rich-text';
 import { Y } from '@wordpress/sync';
 
+// @ts-expect-error - This is a TypeScript file, and @wordpress/blocks doesn't have a tsconfig.json?
+import { getBlockTypes } from '@wordpress/blocks';
+
 interface BlockAttributes {
 	[ key: string ]: unknown;
 }
@@ -127,7 +130,18 @@ function createNewYBlock( block: Block ): YBlock {
 					const attributes = new Y.Map(
 						Object.entries( value ).map(
 							( [ attributeKey, attributeValue ] ) => {
-								// Rich-text logic here
+								const isRichText = isRichTextAttribute(
+									block.name,
+									attributeKey
+								);
+
+								if ( isRichText ) {
+									return [
+										attributeKey,
+										new Y.Text( attributeValue as string ),
+									];
+								}
+
 								return [ attributeKey, attributeValue ];
 							}
 						)
@@ -238,8 +252,19 @@ export function mergeCrdtBlocks(
 					const yAttributes = yblock.get( key ) as Y.Map< unknown >;
 					Object.entries( value ).forEach(
 						( [ attributeKey, attributeValue ] ) => {
-							// Rich-text logic here
-							yAttributes.set( attributeKey, attributeValue );
+							const isRichText = isRichTextAttribute(
+								block.name,
+								attributeKey
+							);
+
+							if ( isRichText ) {
+								const ytext = new Y.Text(
+									attributeValue as string
+								);
+								yAttributes.set( attributeKey, ytext );
+							} else {
+								yAttributes.set( attributeKey, attributeValue );
+							}
 						}
 					);
 					break;
@@ -309,4 +334,49 @@ function shouldBlockBeSynced( block: Block ): boolean {
 
 	// Allow all other blocks to be synced.
 	return true;
+}
+
+// Cache rich-text attributes for looked-up block types.
+const cachedRichTextAttributes = new Map< string, Map< string, true > >();
+
+/**
+ * Given a block name and attribute key, return true if the attribute is rich-text typed.
+ *
+ * @param blockName    The name of the block, e.g. 'core/paragraph'.
+ * @param attributeKey The key of the attribute to check, e.g. 'content'.
+ * @return True if the attribute is rich-text typed, false otherwise.
+ */
+function isRichTextAttribute(
+	blockName: string,
+	attributeKey: string
+): boolean {
+	if ( cachedRichTextAttributes.has( blockName ) ) {
+		// If we've already cached the rich-text attributes for this block type,
+		// return the cached value.
+		return (
+			cachedRichTextAttributes.get( blockName )?.has( attributeKey ) ??
+			false
+		);
+	}
+
+	const allRegisteredBlockTypes = getBlockTypes();
+	const matchingBlockType = allRegisteredBlockTypes.find(
+		( blockType ) => blockType.name === blockName
+	);
+
+	const isBlockTypeRegistered = matchingBlockType !== undefined;
+	const richTextAttributeMap = new Map< string, true >();
+
+	if ( isBlockTypeRegistered ) {
+		for ( const [ registeredKey, registeredProperties ] of Object.entries(
+			matchingBlockType.attributes as Record< string, { type: string } >
+		) ) {
+			if ( registeredProperties.type === 'rich-text' ) {
+				richTextAttributeMap.set( registeredKey, true );
+			}
+		}
+	}
+
+	cachedRichTextAttributes.set( blockName, richTextAttributeMap );
+	return richTextAttributeMap.has( attributeKey );
 }

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -38,10 +38,12 @@ export type YBlock = Y.Map<
 	/* validationIssues? is an array of strings. */
 	| string[]
 	/* attributes is a Y.Map< unknown >. */
-	| Y.Map< unknown >
+	| YBlockAttributes
 	/* innerBlocks is a Y.Array< YBlock >. */
 	| Y.Array< YBlock >
 >;
+
+export type YBlockAttributes = Y.Map< Y.Text | unknown >;
 
 // The Y.Map type is not easy to work with. The generic type it accepts represents
 // the possible values of the map, which are varied in our case. This type is
@@ -112,26 +114,35 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 function createNewYAttributeMap(
 	blockName: string,
 	attributes: BlockAttributes
-): Y.Map< Y.Text | unknown > {
+): YBlockAttributes {
 	return new Y.Map(
 		Object.entries( attributes ).map(
-			( [ attributeKey, attributeValue ] ) => {
-				const isRichText = isRichTextAttribute(
-					blockName,
-					attributeKey
-				);
-
-				if ( isRichText && 'string' === typeof attributeValue ) {
-					return [
-						attributeKey,
-						new Y.Text( attributeValue as string ),
-					];
-				}
-
-				return [ attributeKey, attributeValue ];
+			( [ attributeName, attributeValue ] ) => {
+				return [
+					attributeName,
+					createNewYAttributeValue(
+						blockName,
+						attributeName,
+						attributeValue
+					),
+				];
 			}
 		)
 	);
+}
+
+function createNewYAttributeValue(
+	blockName: string,
+	attributeName: string,
+	attributeValue: unknown
+): Y.Text | unknown {
+	const isRichText = isRichTextAttribute( blockName, attributeName );
+
+	if ( isRichText && 'string' === typeof attributeValue ) {
+		return new Y.Text( attributeValue );
+	}
+
+	return attributeValue;
 }
 
 function createNewYBlock( block: Block ): YBlock {
@@ -252,14 +263,41 @@ export function mergeCrdtBlocks(
 		Object.entries( block ).forEach( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'attributes': {
-					if (
-						! fun.equalityDeep( block[ key ], yblock.get( key ) )
-					) {
-						yblock.set(
-							key,
-							createNewYAttributeMap( block.name, value )
-						);
-					}
+					const currentAttributes =
+						( yblock.get( key ) as YBlockAttributes ) ??
+						createNewYAttributeMap( block.name, {} );
+
+					Object.entries( value ).forEach(
+						( [ attributeName, attributeValue ] ) => {
+							if (
+								fun.equalityDeep(
+									currentAttributes.get( attributeName ),
+									attributeValue
+								)
+							) {
+								return;
+							}
+
+							currentAttributes.set(
+								attributeName,
+								createNewYAttributeValue(
+									block.name,
+									attributeName,
+									attributeValue
+								)
+							);
+						}
+					);
+
+					// Delete any attributes that are no longer present.
+					currentAttributes.forEach(
+						( _attrValue: unknown, attrName: string ) => {
+							if ( ! value.hasOwnProperty( attrName ) ) {
+								currentAttributes.delete( attrName );
+							}
+						}
+					);
+
 					break;
 				}
 

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -263,15 +263,24 @@ export function mergeCrdtBlocks(
 		Object.entries( block ).forEach( ( [ key, value ] ) => {
 			switch ( key ) {
 				case 'attributes': {
-					const currentAttributes =
-						( yblock.get( key ) as YBlockAttributes ) ??
-						createNewYAttributeMap( block.name, {} );
+					const currentAttributes = yblock.get(
+						key
+					) as YBlockAttributes;
+
+					// If attributes are not set on the yblock, use the new values.
+					if ( ! currentAttributes ) {
+						yblock.set(
+							key,
+							createNewYAttributeMap( block.name, value )
+						);
+						break;
+					}
 
 					Object.entries( value ).forEach(
 						( [ attributeName, attributeValue ] ) => {
 							if (
 								fun.equalityDeep(
-									currentAttributes.get( attributeName ),
+									currentAttributes?.get( attributeName ),
 									attributeValue
 								)
 							) {

--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -90,7 +90,7 @@ function areBlocksEqual( gblock: Block, yblock: YBlock ): boolean {
 	);
 }
 
-export function mergeBlocks(
+export function mergeCrdtBlocks(
 	yblocks: Y.Array< YBlock >,
 	newValue: Block[] | Y.Array< YBlock >,
 	_origin: string // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -11,7 +11,7 @@ import { type CRDTDoc, Y } from '@wordpress/sync';
 /**
  * Internal dependencies
  */
-import { mergeBlocks, type Block, type YBlock } from './crdt-blocks';
+import { mergeCrdtBlocks, type Block, type YBlock } from './crdt-blocks';
 
 type PrimitiveValue = string | number | boolean | null | undefined;
 
@@ -52,7 +52,7 @@ export function defaultApplyChangesToCRDTDoc(
 
 				// Merge blocks does not need `setValue` because it has been
 				// called above and the result can be operated on directly.
-				mergeBlocks( currentBlocks, newBlocks, origin );
+				mergeCrdtBlocks( currentBlocks, newBlocks, origin );
 				break;
 			}
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -37,9 +37,7 @@ export function defaultApplyChangesToCRDTDoc(
 
 		switch ( key ) {
 			case 'blocks': {
-				let currentBlocks = ymap.get(
-					'blocks'
-				) as PostChanges[ 'blocks' ];
+				let currentBlocks = ymap.get( 'blocks' ) as Y.Array< YBlock >;
 
 				if ( ! ( currentBlocks instanceof Y.Array ) ) {
 					currentBlocks = setValue< Y.Array< YBlock > >(


### PR DESCRIPTION
WIP. Improve consistency of types stored in the Yjs synced document:

1. Change `block` types to `Y.Map`. Previously this was true for root blocks, but not for inner blocks.
1. Change `innerBlocks` use the `Y.Array` type to match root blocks. They were previously a `Block[]`, which was different that the root `blocks` type (`Y.Array< YBlock >`).
2. Change `rich-text` types to use `Y.Text`. We'll probably need more logic to ensure relative position changes bind correctly to text updates, but this is a good start.

All of the consistency updates make parsing blocks more straightforward, and simplify types. This is an important step to implementing relative cursors, and typing within the same rich text block.

We've also improved the `mergeCrdtBlocks()` function to recurse and merge `innerBlocks` with the same strategy as root blocks.