### PR TITLE
Sync the status and ensure the button state is stable

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -264,6 +264,7 @@ async function loadPostTypeEntities() {
 		'tags',
 		'template',
 		'title',
+		'status',
 	] );
 
 	const postTypes = await apiFetch( {

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -26,6 +26,7 @@ import {
 import type * as ET from './entity-types';
 import type { UndoManager } from '@wordpress/undo-manager';
 import logEntityDeprecation from './utils/log-entity-deprecation';
+import { getSyncProvider } from './sync';
 
 // This is an incomplete, high-level approximation of the State type.
 // It makes the selectors slightly more safe, but is intended to evolve
@@ -832,6 +833,42 @@ export const getEntityRecordNonTransientEdits = createSelector(
 	( state: State, kind: string, name: string, recordId: EntityRecordKey ) => [
 		state.entities.config,
 		state.entities.records?.[ kind ]?.[ name ]?.edits?.[ recordId ],
+	]
+);
+
+/**
+ * Returns an entity property from the sync procider.
+ *
+ * This is only restricted to status for now, and is applicable only to entities
+ * that support syncing.
+ *
+ * @param state     State tree.
+ * @param kind      Entity kind.
+ * @param name      Entity name.
+ * @param recordId  Record ID.
+ * @param lookupKey The property to look up from the CRDT document.
+ *
+ * @return The property value from the sync provider, or null if not found or not applicable.
+ */
+export const getEntityPropertyFromSyncProvider = createSelector(
+	(
+		state: State,
+		kind: string,
+		name: string,
+		recordId: EntityRecordKey,
+		lookupKey: 'status'
+	): string | null => {
+		const { syncConfig } = getEntityConfig( state, kind, name ) || {};
+
+		if ( ! syncConfig || ! syncConfig.objectType ) {
+			return null;
+		}
+
+		return getSyncProvider().getProperty( syncConfig.objectType, { id: recordId }, lookupKey );
+	},
+	( state: State, kind: string, name: string, recordId: EntityRecordKey ) => [
+		state.entities.config,
+		state.entities.records?.[ kind ]?.[ name ]?.edits?.[ recordId ]
 	]
 );
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -837,7 +837,7 @@ export const getEntityRecordNonTransientEdits = createSelector(
 );
 
 /**
- * Returns an entity property from the sync procider.
+ * Returns an entity property from the sync provider.
  *
  * This is only restricted to status for now, and is applicable only to entities
  * that support syncing.

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -18,6 +18,7 @@ type PrimitiveValue = string | number | boolean | null | undefined;
 interface PostChanges {
 	blocks?: Y.Array< YBlock > | Block[];
 	title?: string | { raw: string };
+	status?: string;
 }
 
 export function defaultApplyChangesToCRDTDoc(
@@ -67,6 +68,21 @@ export function defaultApplyChangesToCRDTDoc(
 				}
 
 				mergePrimitiveValue( currentValue, rawNewValue, setValue );
+				break;
+			}
+
+			case 'status': {
+				const currentValue = ymap.get(
+					'status'
+				) as PostChanges[ 'status' ];
+
+				// Copy logic from prePersistPostType to ensure that "auto-draft"
+				// status is not synced.
+				if ( newValue === 'auto-draft' ) {
+					newValue = 'draft';
+				}
+
+				mergePrimitiveValue( currentValue, newValue, setValue );
 				break;
 			}
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -162,6 +162,18 @@ export const getCurrentPost = createRegistrySelector(
 			postType,
 			postId
 		);
+
+		// If the post status has changed according to the sync provider, update the post status here.
+		// This'll ensure that the publish panel shows the correct status.
+		// auto-draft posts are excluded here as that's the default status for new posts.
+		if ( post && post.id ) {
+			const status = select( coreStore ).getEntityPropertyFromSyncProvider( 'postType', postType, post.id, 'status' );
+
+			if ( status && status !== 'auto-draft' && status !== post.status ) {
+				post.status = status;
+			}
+		}
+
 		if ( post ) {
 			return post;
 		}

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -298,6 +298,43 @@ export class SyncProvider {
 	}
 
 	/**
+	 * Fetch a property from the ydoc.
+	 *
+	 * Currently only supports fetching the 'status' property.
+	 *
+	 * @param {ObjectType} objectType Object type to load.
+	 * @param {ObjectData} record     Record to load.
+	 * @param {string}     lookupKey  The property to look up.
+	 * @return {string | null} The property value, or null if not found.
+	 */
+	public getProperty(
+		objectType: ObjectType,
+		record: ObjectData,
+		lookupKey: 'status'
+	): string | null {
+		const syncConfig = this.configs.get( objectType );
+		const objectId = syncConfig?.getObjectId( record );
+
+		if ( ! syncConfig || ! objectId ) {
+			return null;
+		}
+
+		const ydoc = this.getEntityState( objectType, objectId )?.ydoc;
+
+		if ( ! ydoc ) {
+			return null;
+		}
+
+		const ymap = ydoc.getMap( 'document' );
+
+		if ( ! ymap.has( lookupKey ) ) {
+			return null;
+		}
+
+		return ymap.get( lookupKey ) as string;
+	}
+
+	/**
 	 * Stop updating a document and discard it.
 	 *
 	 * @param {ObjectType} objectType Object type to discard.


### PR DESCRIPTION
### Description

The purpose behind this PR is to sync the status between clients, to ensure that Gutenberg updates the UI in accordance with any status changes. This means that, the status is set within the ydoc and is exposed so it could be queried by any one. It's never set to `auto-draft`, and the `getCurrentPost` selector has been updated to take advantage of this new selector.

https://github.com/user-attachments/assets/7fe93e9d-5f81-4cd8-b492-fe40c3acc6d9

The active client sees the publish and save button always. The client that's not "active" will see just the save button at first. Once they save something, the publish button is visible to them. It's better than what was seen before imo.

I've tested this thoroughly, and ensured that there are no data losses or any funny behaviour. That said, please battle test this and go nuts trying to break it because that's important to discover early on.