### PR TITLE
Disable autosave warnings when collaborative editing is enabled

### DIFF
--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -101,6 +101,19 @@ function useAutosaveNotice() {
 			return;
 		}
 
+		// Disable the warning notice if collaborative editing is enabled.
+		//
+		// @TODO
+		//
+		// In the future, we may wish to implement a more sophisticated check -- for
+		// example, if collaborative editing is enabled but the provider is
+		// disconnected, we may want to provide the user with options. For now,
+		// however, since we effectively lock the editor when the provider is not
+		// connected, this simplistic approach will work.
+		if ( window.__experimentalEnableSync ) {
+			return;
+		}
+
 		const id = 'wpEditorAutosaveRestore';
 
 		createWarningNotice(

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -293,7 +293,17 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 			updatePostLock( settings.postLock );
 			setupEditor( post, initialEdits, settings.template );
-			if ( settings.autosave ) {
+
+			// Disable the warning notice if collaborative editing is enabled.
+			//
+			// @TODO
+			//
+			// In the future, we may wish to implement a more sophisticated check -- for
+			// example, if collaborative editing is enabled but the provider is
+			// disconnected, we may want to provide the user with options. For now,
+			// however, since we effectively lock the editor when the provider is not
+			// connected, this simplistic approach will work.
+			if ( settings.autosave && ! window.__experimentalEnableSync ) {
 				createWarningNotice(
 					__(
 						'There is an autosave of this post that is more recent than the version below.'


### PR DESCRIPTION
Disable autosave warnings when collaborative editing is enabled. This means that autosaves still happen, both local and remote (DB-persisted), but we simply suppress the warning notices that lead the user towards possibly confusing actions.

As noted in the comments, we may wish to pursue more sophisticated behavior in the future, but this achieves our short-term goal of preventing users from easily disrupting a collaborative editing session with an autosave restore.