### PR TITLE
Sync status and preserve "dirty / clean" state

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -13,18 +13,13 @@ import { parse } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { defaultApplyChangesToCRDTDoc } from './utils/crdt';
+import {
+	defaultApplyChangesToCRDTDoc,
+	defaultGetChangesFromCRDTDoc,
+} from './utils/crdt';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
-
-/**
- * @param {Y.Doc} ydoc
- * @return {import('@wordpress/sync').ObjectData} The JSON representation of the document.
- */
-const defaultFromCRDTDoc = ( ydoc ) => {
-	return ydoc.getMap( 'document' ).toJSON();
-};
 
 export const rootEntitiesConfig = [
 	{
@@ -257,9 +252,8 @@ async function loadPostTypeEntities() {
 		'blocks',
 		'featured_media',
 		'format',
-		'generated_slug',
 		'password',
-		'slug',
+		'status',
 		'sticky',
 		'tags',
 		'template',
@@ -304,7 +298,7 @@ async function loadPostTypeEntities() {
 				),
 
 				/**
-				 * Apply changes from the local editor and to the local CRDT document so
+				 * Apply changes from the local editor to the local CRDT document so
 				 * that those changes can be synced to other peers (via the provider).
 				 *
 				 * @param {import('@wordpress/sync').CRDTDoc}    crdtDoc
@@ -313,17 +307,10 @@ async function loadPostTypeEntities() {
 				 * @return {void}
 				 */
 				applyChangesToCRDTDoc: ( crdtDoc, changes, origin ) => {
-					const filteredChanges = Object.fromEntries(
-						Object.entries( changes ).filter(
-							( [ key, value ] ) =>
-								syncedProperties.has( key ) &&
-								'function' !== typeof value // cannot serialize function values
-						)
-					);
-
 					defaultApplyChangesToCRDTDoc(
 						crdtDoc,
-						filteredChanges,
+						changes,
+						syncedProperties,
 						origin
 					);
 				},
@@ -332,10 +319,16 @@ async function loadPostTypeEntities() {
 				 * Transform a CRDT document into a partial record that can be used to
 				 * update the local editor state.
 				 *
-				 * @param {import('@wordpress/sync').CRDTDoc} crdtDoc
-				 * @return {import('@wordpress/sync').ObjectData} Object data
+				 * @param {import('@wordpress/sync').CRDTDoc}    crdtDoc
+				 * @param {import('@wordpress/sync').ObjectData} record
+				 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
 				 */
-				fromCRDTDoc: defaultFromCRDTDoc,
+				getChangesFromCRDTDoc: ( crdtDoc, record ) =>
+					defaultGetChangesFromCRDTDoc(
+						crdtDoc,
+						record,
+						syncedProperties
+					),
 
 				/**
 				 * This initial object data represents the data that will be synced via

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -153,10 +153,11 @@ export const getEntityRecord =
 				! query
 			) {
 				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-					// Loads the persisted document.
 					await getSyncProvider().bootstrap(
+						// Bootstrap syncing for the entity.
 						entityConfig.syncConfig,
 						record,
+						// Handle changes from remote peers.
 						( edits ) => {
 							dispatch( {
 								type: 'EDIT_ENTITY_RECORD',
@@ -168,7 +169,14 @@ export const getEntityRecord =
 									undo: undefined,
 								},
 							} );
-						}
+						},
+						// Get the current entity record.
+						async () =>
+							await resolveSelect.getEntityRecord(
+								kind,
+								name,
+								key
+							)
 					);
 				}
 			}

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -36,7 +36,7 @@ export function defaultApplyChangesToCRDTDoc(
 		}
 
 		// Cannot serialize function values, so cannot sync them.
-		if ( 'function' !== typeof newValue ) {
+		if ( 'function' === typeof newValue ) {
 			return;
 		}
 

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -6,28 +6,40 @@ import * as fun from 'lib0/function';
 /**
  * WordPress dependencies
  */
-import { type CRDTDoc, Y } from '@wordpress/sync';
+import { type CRDTDoc, type ObjectData, Y } from '@wordpress/sync';
 
 /**
  * Internal dependencies
  */
 import { mergeCrdtBlocks, type Block, type YBlock } from './crdt-blocks';
 
+type MaybeRawValue = string | { raw: string };
 type PrimitiveValue = string | number | boolean | null | undefined;
 
 interface PostChanges {
-	blocks?: Y.Array< YBlock > | Block[];
-	title?: string | { raw: string };
+	blocks?: Block[];
+	status?: string;
+	title?: MaybeRawValue;
 }
 
 export function defaultApplyChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: PostChanges,
+	syncedProperties: Set< string >,
 	origin: string
 ): void {
 	const ymap = ydoc.getMap( 'document' );
 
 	Object.entries( changes ).forEach( ( [ key, newValue ] ) => {
+		if ( ! syncedProperties.has( key ) ) {
+			return;
+		}
+
+		// Cannot serialize function values, so cannot sync them.
+		if ( 'function' !== typeof newValue ) {
+			return;
+		}
+
 		// Return .get() result so that caller can operate on the data type
 		// without having to call .get() themselves.
 		function setValue< T = unknown >( updatedValue: T ): T {
@@ -55,13 +67,11 @@ export function defaultApplyChangesToCRDTDoc(
 			}
 
 			case 'title': {
-				const currentValue = ymap.get(
-					'title'
-				) as PostChanges[ 'title' ];
+				const currentValue = ymap.get( 'title' ) as string | undefined;
 
 				// Copy logic from prePersistPostType to ensure that the "Auto
 				// Draft" template title is not synced.
-				let rawNewValue = newValue?.raw ?? newValue;
+				let rawNewValue = getRawValue( newValue );
 				if ( ! currentValue && 'Auto Draft' === rawNewValue ) {
 					rawNewValue = '';
 				}
@@ -80,12 +90,81 @@ export function defaultApplyChangesToCRDTDoc(
 	} );
 }
 
-export function mergePrimitiveValue< ValueType extends PrimitiveValue >(
+/**
+ * Given a local Y.Doc that *may* contain changes from remote peers, compare
+ * against the local record and determine if there are changes (edits) we want
+ * to dispatch.
+ *
+ * @param {CRDTDoc}       ydoc
+ * @param {ObjectData}    record
+ * @param {Set< string >} syncedProperties
+ */
+export function defaultGetChangesFromCRDTDoc(
+	ydoc: CRDTDoc,
+	record: ObjectData,
+	syncedProperties: Set< string >
+): Partial< ObjectData > {
+	return Object.fromEntries(
+		Object.entries(
+			ydoc.getMap( 'document' ).toJSON() as PostChanges
+		).filter( ( [ key, newValue ] ) => {
+			if ( ! syncedProperties.has( key ) ) {
+				return false;
+			}
+
+			const currentValue = record[ key ];
+
+			switch ( key ) {
+				case 'status': {
+					// Do not sync a status is not "ready".
+					if ( ! newValue || 'auto-draft' === newValue ) {
+						return false;
+					}
+
+					return haveValuesChanged( currentValue, newValue );
+				}
+
+				case 'title': {
+					return haveValuesChanged(
+						getRawValue( currentValue as PostChanges[ 'title' ] ),
+						newValue
+					);
+				}
+
+				// Add support for additional data types here. Note that we don't need
+				// to add special equality checks for `blocks` here since that is done
+				// by the store for us!
+
+				default: {
+					return haveValuesChanged( currentValue, newValue );
+				}
+			}
+		} )
+	);
+}
+
+function haveValuesChanged< ValueType extends PrimitiveValue >(
+	currentValue: ValueType,
+	newValue: ValueType
+): boolean {
+	return ! fun.equalityDeep( currentValue, newValue );
+}
+
+function getRawValue( value?: MaybeRawValue ): string | undefined {
+	// Value may be a string property or a nested object with a `raw` property.
+	if ( 'string' === typeof value ) {
+		return value;
+	}
+
+	return value?.raw;
+}
+
+function mergePrimitiveValue< ValueType extends PrimitiveValue >(
 	currentValue: ValueType,
 	newValue: ValueType,
 	setValue: ( value: ValueType ) => ValueType
 ): void {
-	if ( ! fun.equalityDeep( currentValue, newValue ) ) {
+	if ( haveValuesChanged( currentValue, newValue ) ) {
 		setValue( newValue );
 	}
 }

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -87,14 +87,16 @@ export class SyncProvider {
 	/**
 	 * Fetch data from local database or remote source.
 	 *
-	 * @param {SyncConfig} syncConfig    Sync configuration for the object type.
-	 * @param {ObjectData} record        Record representing this object type.
-	 * @param {Function}   handleChanges Callback to call when data changes.
+	 * @param {SyncConfig} syncConfig            Sync configuration for the object type.
+	 * @param {ObjectData} record                Record representing this object type.
+	 * @param {Function}   handleChangesToRecord Callback to call when record should be updated.
+	 * @param {Function}   getCurrentRecord      Get current record.
 	 */
 	public async bootstrap(
 		syncConfig: SyncConfig,
 		record: ObjectData,
-		handleChanges: ( data: Partial< ObjectData > ) => void
+		handleChangesToRecord: ( data: Partial< ObjectData > ) => void,
+		getCurrentRecord: () => Promise< ObjectData >
 	): Promise< void > {
 		const meta = new Map< string, unknown >( [
 			[ 'version', CRDT_DOC_VERSION ],
@@ -112,14 +114,24 @@ export class SyncProvider {
 			this.entityStates.delete( entityId );
 		};
 
-		const onUpdate = ( _update: Uint8Array, origin: string ): void => {
-			if ( origin !== 'gutenberg' ) {
-				const data = syncConfig.fromCRDTDoc( ydoc );
-				handleChanges( data );
-			}
+		const onUpdate = async (): Promise< void > => {
+			// Determine which data has actually changed.
+			const changes = syncConfig.getChangesFromCRDTDoc(
+				ydoc,
+				await getCurrentRecord()
+			);
+
+			// This is a good spot to debug to see which changes are being synced. Note
+			// that `blocks` will always appear in the changes.
+
+			handleChangesToRecord( changes );
 		};
 
-		ydoc.on( 'update', onUpdate );
+		ydoc.on( 'update', ( _update: Uint8Array, origin: string ): void => {
+			if ( origin !== 'gutenberg' ) {
+				void onUpdate();
+			}
+		} );
 
 		if ( syncConfig.supportsUndo ) {
 			this.undoManager = new UndoManager( ydoc );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -36,7 +36,7 @@ export type SyncConfig = {
 		data: Partial< ObjectData >,
 		origin: string
 	) => void;
-	fromCRDTDoc: ( ydoc: Y.Doc ) => ObjectData;
+	getChangesFromCRDTDoc: ( ydoc: Y.Doc, record: ObjectData ) => ObjectData;
 	getInitialObjectData: ( record: ObjectData ) => ObjectData;
 	getObjectId: ( data: ObjectData ) => ObjectID;
 	objectType: ObjectType;


### PR DESCRIPTION
Sync a post's status and preserve "dirty / clean" state. We do this primarily by (1) syncing only "known-good" statuses and (2) preventing dispatched edits when we know the data has not changed. This requires the `SyncProvider` to get the current record to enable comparisons. **Note the companion plugin PR.**

- Add `status` to synced properties
- Rename `fromCRDTDoc` to `getChangesFromCRDTDoc`
- Pass in `getCurrentRecord` to `SyncProvider#bootstrap`
- Provide comparison logic in `getChangesFromCRDTDoc` so that we only dispatch known changes
- Remove `slug` and `generated_slug` from synced properties
