### PR TITLE
Sync persisted entity via refetch

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -701,6 +701,15 @@ export const saveEntityRecord =
 						true,
 						edits
 					);
+					if (
+						window.__experimentalEnableSync &&
+						entityConfig.syncConfig?.enabled
+					) {
+						getSyncProvider().markEntityAsPersisted(
+							entityConfig.syncConfig,
+							persistedRecord
+						);
+					}
 				}
 			} catch ( _error ) {
 				hasError = true;

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -401,7 +401,7 @@ export const editEntityRecord =
 		if ( window.__experimentalEnableSync && entityConfig.syncConfig ) {
 			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 				getSyncProvider().updateCRDTDoc(
-					entityConfig.syncConfig.objectType,
+					entityConfig.syncConfig,
 					record,
 					edit.edits,
 					'gutenberg'
@@ -705,7 +705,7 @@ export const saveEntityRecord =
 						window.__experimentalEnableSync &&
 						entityConfig.syncConfig?.enabled
 					) {
-						getSyncProvider().markEntityAsPersisted(
+						getSyncProvider().updateLastPersistedDate(
 							entityConfig.syncConfig,
 							persistedRecord
 						);

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -400,9 +400,7 @@ export const editEntityRecord =
 		};
 		if ( window.__experimentalEnableSync && entityConfig.syncConfig ) {
 			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-				// @todo this always updates the Yjs doc, which is undesirable, probably we can read the yjs
-				// content from the comment tag here
-				getSyncProvider().update(
+				getSyncProvider().updateCRDTDoc(
 					entityConfig.syncConfig.objectType,
 					record,
 					edit.edits,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -322,8 +322,8 @@ async function loadPostTypeEntities() {
 				},
 
 				/**
-				 * Transform a CRDT document into a partial record that can be used to
-				 * update the local editor state.
+				 * Extract changes from a CRDT document that can be used to update the
+				 * local editor state.
 				 *
 				 * @param {import('@wordpress/sync').CRDTDoc}    crdtDoc
 				 * @param {import('@wordpress/sync').ObjectData} record
@@ -366,9 +366,18 @@ async function loadPostTypeEntities() {
 				 */
 				getObjectId: ( { id } ) => id,
 
+				/**
+				 * The object type for the entity, used to scope CRDT documents.
+				 */
 				objectType: `postType/${ postType.slug }`,
-				supportsAwareness: true,
-				supportsUndo: true,
+
+				/**
+				 * Sync features supported by the entity.
+				 */
+				supports: {
+					awareness: true,
+					undo: true,
+				},
 			},
 			supportsPagination: true,
 			getRevisionsUrl: ( parentId, revisionId ) =>

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -13,18 +13,13 @@ import { parse } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { defaultApplyChangesToCRDTDoc } from './utils/crdt';
+import {
+	applyPostChangesToCRDTDoc,
+	getPostChangesFromCRDTDoc,
+} from './utils/crdt';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
-
-/**
- * @param {Y.Doc} ydoc
- * @return {import('@wordpress/sync').ObjectData} The JSON representation of the document.
- */
-const defaultFromCRDTDoc = ( ydoc ) => {
-	return ydoc.getMap( 'document' ).toJSON();
-};
 
 export const rootEntitiesConfig = [
 	{
@@ -254,15 +249,18 @@ export const prePersistPostType = ( persistedRecord, edits ) => {
  */
 async function loadPostTypeEntities() {
 	const syncedProperties = new Set( [
+		'author',
 		'blocks',
+		'comment_status',
+		'date',
+		'excerpt',
 		'featured_media',
 		'format',
-		'generated_slug',
-		'password',
-		'slug',
-		'sticky',
+		'ping_status',
+		'status',
 		'tags',
 		'template',
+		'slug',
 		'title',
 	] );
 
@@ -304,26 +302,21 @@ async function loadPostTypeEntities() {
 				),
 
 				/**
-				 * Apply changes from the local editor and to the local CRDT document so
+				 * Apply changes from the local editor to the local CRDT document so
 				 * that those changes can be synced to other peers (via the provider).
 				 *
-				 * @param {import('@wordpress/sync').CRDTDoc}    crdtDoc
-				 * @param {import('@wordpress/sync').ObjectData} changes
-				 * @param {string}                               origin
+				 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
+				 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
+				 * @param {import('@wordpress/sync').ObjectData}            record
+				 * @param {string}                                          origin
 				 * @return {void}
 				 */
-				applyChangesToCRDTDoc: ( crdtDoc, changes, origin ) => {
-					const filteredChanges = Object.fromEntries(
-						Object.entries( changes ).filter(
-							( [ key, value ] ) =>
-								syncedProperties.has( key ) &&
-								'function' !== typeof value // cannot serialize function values
-						)
-					);
-
-					defaultApplyChangesToCRDTDoc(
+				applyChangesToCRDTDoc: ( crdtDoc, changes, record, origin ) => {
+					applyPostChangesToCRDTDoc(
 						crdtDoc,
-						filteredChanges,
+						changes,
+						record,
+						syncedProperties,
 						origin
 					);
 				},
@@ -332,10 +325,16 @@ async function loadPostTypeEntities() {
 				 * Transform a CRDT document into a partial record that can be used to
 				 * update the local editor state.
 				 *
-				 * @param {import('@wordpress/sync').CRDTDoc} crdtDoc
-				 * @return {import('@wordpress/sync').ObjectData} Object data
+				 * @param {import('@wordpress/sync').CRDTDoc}    crdtDoc
+				 * @param {import('@wordpress/sync').ObjectData} record
+				 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
 				 */
-				fromCRDTDoc: defaultFromCRDTDoc,
+				getChangesFromCRDTDoc: ( crdtDoc, record ) =>
+					getPostChangesFromCRDTDoc(
+						crdtDoc,
+						record,
+						syncedProperties
+					),
 
 				/**
 				 * This initial object data represents the data that will be synced via

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -178,6 +178,17 @@ export const getEntityRecord =
 									name,
 									key
 								),
+							// Refetch the persisted entity record.
+							refetchPersistedRecord: () => {
+								void ( async () => {
+									dispatch.receiveEntityRecords(
+										kind,
+										name,
+										await apiFetch( { path, parse: true } ),
+										query
+									);
+								} )();
+							},
 						}
 					);
 				}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -153,21 +153,31 @@ export const getEntityRecord =
 				! query
 			) {
 				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-					// Loads the persisted document.
 					await getSyncProvider().bootstrap(
+						// Bootstrap syncing for the entity.
 						entityConfig.syncConfig,
 						record,
-						( edits ) => {
-							dispatch( {
-								type: 'EDIT_ENTITY_RECORD',
-								kind,
-								name,
-								recordId: key,
-								edits,
-								meta: {
-									undo: undefined,
-								},
-							} );
+						{
+							// Handle edits sourced from the sync provider.
+							editRecord: ( edits ) => {
+								dispatch( {
+									type: 'EDIT_ENTITY_RECORD',
+									kind,
+									name,
+									recordId: key,
+									edits,
+									meta: {
+										undo: undefined,
+									},
+								} );
+							},
+							// Get the current entity record.
+							getEditedRecord: async () =>
+								await resolveSelect.getEditedEntityRecord(
+									kind,
+									name,
+									key
+								),
 						}
 					);
 				}

--- a/packages/core-data/src/sync.ts
+++ b/packages/core-data/src/sync.ts
@@ -25,7 +25,7 @@ export function getSyncProvider(): SyncProvider {
 		return syncProvider;
 	}
 
-	const fallbackNoOpSyncProvider = new SyncProvider( null, null );
+	const fallbackNoOpSyncProvider = new SyncProvider();
 
 	syncProvider = applyFilters(
 		'core.getSyncProvider',

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -6,28 +6,45 @@ import * as fun from 'lib0/function';
 /**
  * WordPress dependencies
  */
-import { type CRDTDoc, Y } from '@wordpress/sync';
+import { type CRDTDoc, type ObjectData, Y } from '@wordpress/sync';
 
 /**
  * Internal dependencies
  */
 import { mergeCrdtBlocks, type Block, type YBlock } from './crdt-blocks';
 
-type PrimitiveValue = string | number | boolean | null | undefined;
+type MaybeRawValue = string | { raw: string };
 
 interface PostChanges {
-	blocks?: Y.Array< YBlock > | Block[];
-	title?: string | { raw: string };
+	blocks?: Block[];
+	excerpt?: MaybeRawValue;
+	status?: string;
+	title?: MaybeRawValue;
 }
 
-export function defaultApplyChangesToCRDTDoc(
+// Key used to store the document map in the Y.Doc.
+const DOCUMENT_MAP_KEY = 'document';
+
+export function applyPostChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: PostChanges,
+	record: ObjectData,
+	syncedProperties: Set< string >,
 	origin: string
 ): void {
-	const ymap = ydoc.getMap( 'document' );
+	const ymap = ydoc.getMap( DOCUMENT_MAP_KEY );
 
 	Object.entries( changes ).forEach( ( [ key, newValue ] ) => {
+		if ( ! syncedProperties.has( key ) ) {
+			ymap.delete( key );
+			return;
+		}
+
+		// Cannot serialize function values, so cannot sync them.
+		if ( 'function' === typeof newValue ) {
+			return;
+		}
+
 		// Return .get() result so that caller can operate on the data type
 		// without having to call .get() themselves.
 		function setValue< T = unknown >( updatedValue: T ): T {
@@ -45,28 +62,62 @@ export function defaultApplyChangesToCRDTDoc(
 					); // Initialize
 				}
 
-				// Block[] from local changes or Y.Array< Y.Map > from peer.
+				// Block[] from local changes.
 				const newBlocks = newValue ?? [];
 
-				// Merge blocks does not need `setValue` because it has been
-				// called above and the result can be operated on directly.
+				// Merge blocks does not need `setValue` because it is operating on a
+				// Yjs type that is already in the Y.Doc.
 				mergeCrdtBlocks( currentBlocks, newBlocks, origin );
 				break;
 			}
 
+			case 'excerpt': {
+				const currentValue = ymap.get( 'excerpt' ) as
+					| string
+					| undefined;
+				const rawNewValue = getRawValue( newValue );
+
+				mergeValue( currentValue, rawNewValue, setValue );
+				break;
+			}
+
+			case 'slug': {
+				// Do not sync an empty slug. This indicates that the post is using
+				// the default auto-generated slug.
+				if ( ! newValue ) {
+					break;
+				}
+
+				const currentValue = ymap.get( 'slug' ) as string;
+				mergeValue( currentValue, newValue, setValue );
+				break;
+			}
+
+			case 'status': {
+				const currentValue = ymap.get( 'status' ) as string | undefined;
+				let newStatus = newValue;
+
+				// Undefined status indicates that we want to reset to the current
+				// persisted value.
+				if ( undefined === newStatus ) {
+					newStatus = record.status;
+				}
+
+				mergeValue( currentValue, newStatus, setValue );
+				break;
+			}
+
 			case 'title': {
-				const currentValue = ymap.get(
-					'title'
-				) as PostChanges[ 'title' ];
+				const currentValue = ymap.get( 'title' ) as string | undefined;
 
 				// Copy logic from prePersistPostType to ensure that the "Auto
 				// Draft" template title is not synced.
-				let rawNewValue = newValue?.raw ?? newValue;
+				let rawNewValue = getRawValue( newValue );
 				if ( ! currentValue && 'Auto Draft' === rawNewValue ) {
 					rawNewValue = '';
 				}
 
-				mergePrimitiveValue( currentValue, rawNewValue, setValue );
+				mergeValue( currentValue, rawNewValue, setValue );
 				break;
 			}
 
@@ -74,18 +125,109 @@ export function defaultApplyChangesToCRDTDoc(
 
 			default: {
 				const currentValue = ymap.get( key );
-				mergePrimitiveValue( currentValue, newValue, setValue );
+				mergeValue( currentValue, newValue, setValue );
 			}
 		}
 	} );
 }
 
-export function mergePrimitiveValue< ValueType extends PrimitiveValue >(
+/**
+ * Given a local Y.Doc that *may* contain changes from remote peers, compare
+ * against the local record and determine if there are changes (edits) we want
+ * to dispatch.
+ *
+ * @param {CRDTDoc}       ydoc
+ * @param {ObjectData}    record
+ * @param {Set< string >} syncedProperties
+ */
+export function getPostChangesFromCRDTDoc(
+	ydoc: CRDTDoc,
+	record: ObjectData,
+	syncedProperties: Set< string >
+): Partial< PostChanges > {
+	const ymap = ydoc.getMap( DOCUMENT_MAP_KEY );
+
+	return Object.fromEntries(
+		Object.entries( ymap.toJSON() ).filter( ( [ key, newValue ] ) => {
+			if ( ! syncedProperties.has( key ) ) {
+				return false;
+			}
+
+			const currentValue = record[ key ];
+
+			switch ( key ) {
+				case 'blocks': {
+					// We don't need to add special equality checks for `blocks` here
+					// since that is done by the store for us!
+					return true;
+				}
+
+				case 'date': {
+					// Do not sync an empty date if our current value is a "floating" date.
+					// Borrowing logic from the isEditedPostDateFloating selector.
+					const currentDateIsFloating =
+						[ 'draft', 'auto-draft', 'pending' ].includes(
+							ymap.get( 'status' ) as string
+						) &&
+						( null === currentValue ||
+							record.modified === currentValue );
+
+					if ( ! newValue && currentDateIsFloating ) {
+						return false;
+					}
+
+					return haveValuesChanged( currentValue, newValue );
+				}
+
+				case 'status': {
+					// Do not sync an invalid status.
+					if ( 'auto-draft' === newValue ) {
+						return false;
+					}
+
+					return haveValuesChanged( currentValue, newValue );
+				}
+
+				case 'excerpt':
+				case 'title': {
+					return haveValuesChanged(
+						getRawValue( currentValue as MaybeRawValue ),
+						newValue
+					);
+				}
+
+				// Add support for additional data types here.
+
+				default: {
+					return haveValuesChanged( currentValue, newValue );
+				}
+			}
+		} )
+	);
+}
+
+function getRawValue( value?: MaybeRawValue ): string | undefined {
+	// Value may be a string property or a nested object with a `raw` property.
+	if ( 'string' === typeof value ) {
+		return value;
+	}
+
+	return value?.raw;
+}
+
+function haveValuesChanged< ValueType = any >(
+	currentValue: ValueType,
+	newValue: ValueType
+): boolean {
+	return ! fun.equalityDeep( currentValue, newValue );
+}
+
+function mergeValue< ValueType = any >(
 	currentValue: ValueType,
 	newValue: ValueType,
 	setValue: ( value: ValueType ) => ValueType
 ): void {
-	if ( ! fun.equalityDeep( currentValue, newValue ) ) {
+	if ( haveValuesChanged< ValueType >( currentValue, newValue ) ) {
 		setValue( newValue );
 	}
 }

--- a/packages/sync/src/config.ts
+++ b/packages/sync/src/config.ts
@@ -1,0 +1,4 @@
+// This version number should be incremented whenever there are breaking changes
+// to Yjs doc schema or in how it is interpreted by code in the SyncConfig. This
+// allows implementors to invalidate persisted CRDT docs, if any.
+export const CRDT_DOC_VERSION = 1;

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -35,7 +35,7 @@ declare global {
  * @return {SyncProvider} The WebRTC sync provider.
  */
 export function getWebRTCSyncProvider(): SyncProvider {
-	return new SyncProvider(
+	return new SyncProvider( [
 		connectIndexDb,
 		createWebRTCConnection( {
 			password: window?.__experimentalCollaborativeEditingSecret,
@@ -43,6 +43,6 @@ export function getWebRTCSyncProvider(): SyncProvider {
 				//'ws://localhost:4444',
 				window?.wp?.ajax?.settings?.url,
 			],
-		} )
-	);
+		} ),
+	] );
 }

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -10,9 +10,10 @@ import { createWebRTCConnection } from './create-webrtc-connection';
 import { SyncProvider } from './provider';
 
 export * as Y from 'yjs';
+export { CRDT_DOC_VERSION } from './config';
 export { connectIndexDb } from './connect-indexdb';
 export { createWebRTCConnection } from './create-webrtc-connection';
-export { CRDT_DOC_VERSION, SyncProvider } from './provider';
+export { SyncProvider } from './provider';
 export * from './types';
 
 declare global {

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -23,8 +23,12 @@ import { createYjsDoc } from './utils';
 
 interface EntityState {
 	destroy: () => void;
+	lastPersistedAt: number;
 	ydoc: CRDTDoc;
 }
+
+const CRDT_STATE_MAP_KEY = 'state';
+const CRDT_STATE_PERSISTED_AT_KEY = 'persistedAt';
 
 export class SyncProvider {
 	private connectLocal: ConnectDoc | null;
@@ -121,6 +125,7 @@ export class SyncProvider {
 		this.connections.set( entityId, connections );
 		this.setEntityState( objectType, objectId, {
 			destroy: onDestroy,
+			lastPersistedAt: Date.now(),
 			ydoc,
 		} );
 
@@ -279,6 +284,17 @@ export class SyncProvider {
 		return this.undoManager;
 	}
 
+	public markEntityAsPersisted(
+		syncConfig: SyncConfig,
+		record: ObjectData
+	): void {
+		const objectId = syncConfig.getObjectId( record );
+		const objectType = syncConfig.objectType;
+		const ydoc = this.getEntityState( objectType, objectId )?.ydoc;
+
+		ydoc?.getMap( 'state' ).set( CRDT_STATE_PERSISTED_AT_KEY, Date.now() );
+	}
+
 	/**
 	 * Update CRDT document with changes from the local store.
 	 *
@@ -322,7 +338,7 @@ export class SyncProvider {
 			return;
 		}
 
-		const { ydoc } = entityState;
+		const { lastPersistedAt, ydoc } = entityState;
 
 		// Determine which synced properties have actually changed by comparing
 		// them against the current entity record.
@@ -333,6 +349,17 @@ export class SyncProvider {
 		// in an update to the store if the blocks have changed.
 
 		handlers.editRecord( changes );
+
+		// Determine if we should refetch the persisted entity record from the
+		// REST API because another client has persisted changes.
+		const ystateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
+		const persistedAt =
+			( ystateMap.get( CRDT_STATE_PERSISTED_AT_KEY ) as number ) ?? 0;
+		if ( persistedAt > lastPersistedAt ) {
+			entityState.lastPersistedAt = persistedAt;
+			this.setEntityState( objectType, objectId, entityState );
+			void handlers.refetchPersistedRecord();
+		}
 	}
 
 	/**

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -22,17 +22,21 @@ import { UndoManager } from './undo-manager';
 import { createYjsDoc } from './utils';
 
 interface EntityState {
-	destroy: () => void;
+	discard: () => void;
+	handlers: RecordHandlers;
 	lastPersistedAt: number;
+	syncConfig: SyncConfig;
+	undoManager?: UndoManager;
 	ydoc: CRDTDoc;
 }
 
 const CRDT_STATE_MAP_KEY = 'state';
 const CRDT_STATE_PERSISTED_AT_KEY = 'persistedAt';
 
+const LOCAL_ORIGINS = [ 'gutenberg', 'syncProvider' ];
+
 export class SyncProvider {
-	private connectLocal: ConnectDoc | null;
-	private connectRemote: ConnectDoc | null;
+	private connectionCreators: ConnectDoc[];
 
 	/**
 	 * CAUTION: We currently store a single UndoManager instance under these
@@ -40,50 +44,24 @@ export class SyncProvider {
 	 *
 	 * 1. Only entities loaded by the block editor support an undo manager.
 	 * 2. Only one such entity is loaded at a time.
-	 * 3. The entity's SyncConfig has `supportsUndo` set to true.
+	 * 3. The entity's SyncConfig has `supports.undo` set to true.
 	 *
 	 * If these assumptions fail, we will need to refactor the selectors provided
 	 * by `@wordpress/core-data` (e.g., `getUndoManager`) to support multiple
 	 * UndoManager instances by requiring the entity type and ID as parameters.
 	 */
-	private undoManager: UndoManager | null = null;
+	private undoManager: UndoManager | undefined;
 
-	protected configs: Map< ObjectType, SyncConfig > = new Map();
 	protected connections: Map< EntityID, ConnectDocResult[] > = new Map();
 	protected entityStates: Map< EntityID, EntityState > = new Map();
 
 	/**
 	 * Constructor.
 	 *
-	 * @param {ConnectDoc | null} connectLocal  Connect the document to a local database.
-	 * @param {ConnectDoc | null} connectRemote Connect the document to a remote sync connection.
+	 * @param {ConnectDoc[]} connectionCreators Functions that create Yjs connection providers.
 	 */
-	public constructor(
-		connectLocal: ConnectDoc | null,
-		connectRemote: ConnectDoc | null
-	) {
-		this.connectLocal = connectLocal;
-		this.connectRemote = connectRemote;
-	}
-
-	/**
-	 * Connect to a document.
-	 *
-	 * @param {ObjectID}   objectId   Object ID to connect.
-	 * @param {ObjectType} objectType Object type to connect.
-	 * @param {CRDTDoc}    ydoc       Yjs document for the object.
-	 */
-	private async connect(
-		objectId: ObjectID,
-		objectType: ObjectType,
-		ydoc: CRDTDoc
-	): Promise< ConnectDocResult[] > {
-		return (
-			await Promise.all( [
-				this.connectLocal?.( objectId, objectType, ydoc ),
-				this.connectRemote?.( objectId, objectType, ydoc ),
-			] )
-		).filter( ( result ): result is ConnectDocResult => Boolean( result ) );
+	public constructor( connectionCreators: ConnectDoc[] = [] ) {
+		this.connectionCreators = connectionCreators;
 	}
 
 	/**
@@ -104,34 +82,49 @@ export class SyncProvider {
 		const connections = await this.connect( objectId, objectType, ydoc );
 		const entityId = this.getEntityId( objectType, objectId );
 
-		const onDestroy = (): void => {
+		// Clean up connections and in-memory state when the entity is discarded.
+		const onDiscard = (): void => {
 			connections.forEach( ( result ) => result.destroy() );
 			ydoc.off( 'update', onUpdate );
 			ydoc.destroy();
+			this.connections.delete( entityId );
 			this.entityStates.delete( entityId );
 		};
 
+		// When the CRDT document is updated by a connection (not a local origin like
+		// Gutenberg or this SyncProvider), update the local store.
 		const onUpdate = ( _update: Uint8Array, origin: string ): void => {
-			if ( origin !== 'gutenberg' ) {
-				void this.updateEntityRecord( syncConfig, handlers );
+			if ( LOCAL_ORIGINS.includes( origin ) ) {
+				return;
 			}
+
+			void this.updateEntityRecord( objectType, objectId );
 		};
 
-		if ( syncConfig.supportsUndo ) {
-			this.undoManager = new UndoManager( ydoc );
+		const entityState: EntityState = {
+			discard: onDiscard,
+			handlers,
+			lastPersistedAt: Date.now(),
+			syncConfig,
+			ydoc,
+		};
+
+		if ( syncConfig.supports?.undo ) {
+			entityState.undoManager = new UndoManager( ydoc );
+			this.undoManager = entityState.undoManager;
 		}
 
-		this.configs.set( objectType, syncConfig );
 		this.connections.set( entityId, connections );
-		this.setEntityState( objectType, objectId, {
-			destroy: onDestroy,
-			lastPersistedAt: Date.now(),
-			ydoc,
-		} );
+		this.entityStates.set(
+			this.getEntityId( objectType, objectId ),
+			entityState
+		);
 
 		// Get the initial document state.
 		const initialDoc = await this.getInitialCRDTDoc( syncConfig, record );
 
+		// Attach the update listener before applying the initial state so that
+		// we update the entity record in the local store.
 		ydoc.on( 'update', onUpdate );
 
 		// Apply the initial document to the current document as a singular update.
@@ -140,9 +133,40 @@ export class SyncProvider {
 			() => {
 				Y.applyUpdate( ydoc, Y.encodeStateAsUpdate( initialDoc ) );
 			},
-			'syncProvider.bootstrap',
+			'syncProvider',
 			false
 		);
+	}
+
+	/**
+	 * Establish connections for the given entity and its Yjs document.
+	 *
+	 * @param {ObjectID}   objectId   Object ID to connect.
+	 * @param {ObjectType} objectType Object type to connect.
+	 * @param {CRDTDoc}    ydoc       Yjs document for the object.
+	 */
+	private async connect(
+		objectId: ObjectID,
+		objectType: ObjectType,
+		ydoc: CRDTDoc
+	): Promise< ConnectDocResult[] > {
+		return await Promise.all(
+			this.connectionCreators?.map( ( create ) =>
+				create( objectId, objectType, ydoc )
+			)
+		);
+	}
+
+	/**
+	 * Stop syncing an entity and destroy its in-memory state.
+	 *
+	 * @param {ObjectType} objectType Object type to discard.
+	 * @param {ObjectID}   objectId   Object ID to discard.
+	 */
+	public discard( objectType: ObjectType, objectId: ObjectID ): void {
+		this.entityStates
+			.get( this.getEntityId( objectType, objectId ) )
+			?.discard();
 	}
 
 	/**
@@ -156,38 +180,6 @@ export class SyncProvider {
 		objectId: ObjectID
 	): EntityID {
 		return `${ objectType }_${ objectId }`;
-	}
-
-	/**
-	 * Get the entity state for the given object type and object ID.
-	 *
-	 * @param {ObjectType} objectType Object type.
-	 * @param {ObjectID}   objectId   Object ID.
-	 */
-	protected getEntityState(
-		objectType: ObjectType,
-		objectId: ObjectID
-	): EntityState | null {
-		return (
-			this.entityStates.get( this.getEntityId( objectType, objectId ) ) ??
-			null
-		);
-	}
-
-	/**
-	 * Set the entity state for the given object type and object ID.
-	 *
-	 * @param {ObjectType}             objectType Object type.
-	 * @param {ObjectID}               objectId   Object ID.
-	 * @param {Partial< EntityState >} state      Partial entity state to set.
-	 */
-	private setEntityState(
-		objectType: ObjectType,
-		objectId: ObjectID,
-		state: EntityState
-	): void {
-		const entityId = this.getEntityId( objectType, objectId );
-		this.entityStates.set( entityId, state );
 	}
 
 	/**
@@ -281,64 +273,54 @@ export class SyncProvider {
 	 * @return {UndoManager | null} The undo manager, or null if unsupported.
 	 */
 	public getUndoManager(): UndoManager | null {
-		return this.undoManager;
-	}
-
-	public markEntityAsPersisted(
-		syncConfig: SyncConfig,
-		record: ObjectData
-	): void {
-		const objectId = syncConfig.getObjectId( record );
-		const objectType = syncConfig.objectType;
-		const ydoc = this.getEntityState( objectType, objectId )?.ydoc;
-
-		ydoc?.getMap( 'state' ).set( CRDT_STATE_PERSISTED_AT_KEY, Date.now() );
+		return this.undoManager ?? null;
 	}
 
 	/**
 	 * Update CRDT document with changes from the local store.
 	 *
-	 * @param {ObjectType}            objectType Object type to load.
+	 * @param {SyncConfig}            syncConfig Sync configuration for the object type.
 	 * @param {ObjectData}            record     Record to load.
 	 * @param {Partial< ObjectData >} changes    Updates to make.
 	 * @param {string}                origin     The source of change.
 	 */
 	public updateCRDTDoc(
-		objectType: ObjectType,
+		syncConfig: SyncConfig,
 		record: ObjectData,
 		changes: Partial< ObjectData >,
 		origin: string
 	): void {
-		const syncConfig = this.configs.get( objectType );
-		const objectId = syncConfig?.getObjectId( record );
-
-		if ( ! syncConfig || ! objectId ) {
-			return;
-		}
-
-		const ydoc = this.getEntityState( objectType, objectId )?.ydoc;
+		const objectType = syncConfig.objectType;
+		const objectId = syncConfig.getObjectId( record );
+		const entityId = this.getEntityId( objectType, objectId );
+		const ydoc = this.entityStates.get( entityId )?.ydoc;
 
 		ydoc?.transact( () => {
 			syncConfig.applyChangesToCRDTDoc( ydoc, changes, record, origin );
 		}, origin );
 	}
 
+	/**
+	 * Update the entity record in the local store with changes from the CRDT
+	 * document.
+	 *
+	 * @param {ObjectType} objectType Object type of record to update.
+	 * @param {ObjectID}   objectId   Object ID of record to update.
+	 */
 	private async updateEntityRecord(
-		syncConfig: SyncConfig,
-		handlers: RecordHandlers
+		objectType: ObjectType,
+		objectId: ObjectID
 	): Promise< void > {
-		const currentRecord = await handlers.getEditedRecord();
-
-		const objectId = syncConfig.getObjectId( currentRecord );
-		const objectType = syncConfig.objectType;
-
-		const entityState = this.getEntityState( objectType, objectId );
+		const entityId = this.getEntityId( objectType, objectId );
+		const entityState = this.entityStates.get( entityId );
 
 		if ( ! entityState ) {
 			return;
 		}
 
-		const { lastPersistedAt, ydoc } = entityState;
+		const { handlers, lastPersistedAt, syncConfig, ydoc } = entityState;
+
+		const currentRecord = await handlers.getEditedRecord();
 
 		// Determine which synced properties have actually changed by comparing
 		// them against the current entity record.
@@ -356,19 +338,52 @@ export class SyncProvider {
 		const persistedAt =
 			( ystateMap.get( CRDT_STATE_PERSISTED_AT_KEY ) as number ) ?? 0;
 		if ( persistedAt > lastPersistedAt ) {
-			entityState.lastPersistedAt = persistedAt;
-			this.setEntityState( objectType, objectId, entityState );
+			this.entityStates.set( entityId, {
+				...entityState,
+				lastPersistedAt: persistedAt,
+			} );
+
 			void handlers.refetchPersistedRecord();
 		}
 	}
 
 	/**
-	 * Stop updating a document and discard it.
+	 * Update the last persisted timestamp in the CRDT document state map. This is
+	 * used by peers as a signal that they need to refetch the persisted entity.
 	 *
-	 * @param {ObjectType} objectType Object type to discard.
-	 * @param {ObjectID}   objectId   Object ID to discard.
+	 * @param {SyncConfig} syncConfig Sync configuration for the object type.
+	 * @param {ObjectData} record     Record representing this object type.
 	 */
-	public discard( objectType: ObjectType, objectId: ObjectID ): void {
-		this.getEntityState( objectType, objectId )?.destroy();
+	public updateLastPersistedDate(
+		syncConfig: SyncConfig,
+		record: ObjectData
+	): void {
+		const objectId = syncConfig.getObjectId( record );
+		const objectType = syncConfig.objectType;
+		const entityId = this.getEntityId( objectType, objectId );
+		const entityState = this.entityStates.get( entityId );
+
+		if ( ! entityState ) {
+			return;
+		}
+
+		const ydoc = entityState.ydoc;
+		const lastPersistedAt = Date.now();
+
+		// Update in-memory state.
+		this.entityStates.set( entityId, {
+			...entityState,
+			lastPersistedAt,
+		} );
+
+		Y.transact(
+			ydoc,
+			() => {
+				const stateMap = ydoc.getMap( 'state' );
+				stateMap.set( CRDT_STATE_PERSISTED_AT_KEY, lastPersistedAt );
+			},
+			'syncProvider',
+			true
+		);
 	}
 }

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -6,7 +6,7 @@ import * as Y from 'yjs';
 /**
  * Internal dependencies
  */
-import { UndoManager } from './undo-manager';
+import { CRDT_DOC_VERSION } from './config';
 import type {
 	ConnectDoc,
 	ConnectDocResult,
@@ -16,17 +16,15 @@ import type {
 	ObjectData,
 	ObjectType,
 	SyncConfig,
+	RecordHandlers,
 } from './types';
+import { UndoManager } from './undo-manager';
+import { createYjsDoc } from './utils';
 
 interface EntityState {
 	destroy: () => void;
 	ydoc: CRDTDoc;
 }
-
-// This version number should be incremented whenever there are breaking changes
-// to Yjs doc schema or in how it is interpreted by code in the SyncConfig. This
-// allows implementors to invalidate persisted CRDT docs, if any.
-export const CRDT_DOC_VERSION = 1;
 
 export class SyncProvider {
 	private connectLocal: ConnectDoc | null;
@@ -85,23 +83,20 @@ export class SyncProvider {
 	}
 
 	/**
-	 * Fetch data from local database or remote source.
+	 * Bootstrap an entity for syncing and manage its lifecycle.
 	 *
-	 * @param {SyncConfig} syncConfig    Sync configuration for the object type.
-	 * @param {ObjectData} record        Record representing this object type.
-	 * @param {Function}   handleChanges Callback to call when data changes.
+	 * @param {SyncConfig}     syncConfig Sync configuration for the object type.
+	 * @param {ObjectData}     record     Record representing this object type.
+	 * @param {RecordHandlers} handlers   Handlers for updating and fetching the record.
 	 */
 	public async bootstrap(
 		syncConfig: SyncConfig,
 		record: ObjectData,
-		handleChanges: ( data: Partial< ObjectData > ) => void
+		handlers: RecordHandlers
 	): Promise< void > {
-		const meta = new Map< string, unknown >( [
-			[ 'version', CRDT_DOC_VERSION ],
-		] );
-		const ydoc = new Y.Doc( { meta } );
 		const objectId = syncConfig.getObjectId( record );
 		const objectType = syncConfig.objectType;
+		const ydoc = createYjsDoc( objectType );
 		const connections = await this.connect( objectId, objectType, ydoc );
 		const entityId = this.getEntityId( objectType, objectId );
 
@@ -114,12 +109,9 @@ export class SyncProvider {
 
 		const onUpdate = ( _update: Uint8Array, origin: string ): void => {
 			if ( origin !== 'gutenberg' ) {
-				const data = syncConfig.fromCRDTDoc( ydoc );
-				handleChanges( data );
+				void this.updateEntityRecord( syncConfig, handlers );
 			}
 		};
-
-		ydoc.on( 'update', onUpdate );
 
 		if ( syncConfig.supportsUndo ) {
 			this.undoManager = new UndoManager( ydoc );
@@ -127,13 +119,15 @@ export class SyncProvider {
 
 		this.configs.set( objectType, syncConfig );
 		this.connections.set( entityId, connections );
-		this.entityStates.set( entityId, {
+		this.setEntityState( objectType, objectId, {
 			destroy: onDestroy,
 			ydoc,
 		} );
 
 		// Get the initial document state.
 		const initialDoc = await this.getInitialCRDTDoc( syncConfig, record );
+
+		ydoc.on( 'update', onUpdate );
 
 		// Apply the initial document to the current document as a singular update.
 		Y.transact(
@@ -176,6 +170,22 @@ export class SyncProvider {
 	}
 
 	/**
+	 * Set the entity state for the given object type and object ID.
+	 *
+	 * @param {ObjectType}             objectType Object type.
+	 * @param {ObjectID}               objectId   Object ID.
+	 * @param {Partial< EntityState >} state      Partial entity state to set.
+	 */
+	private setEntityState(
+		objectType: ObjectType,
+		objectId: ObjectID,
+		state: EntityState
+	): void {
+		const entityId = this.getEntityId( objectType, objectId );
+		this.entityStates.set( entityId, state );
+	}
+
+	/**
 	 * Get the CRDTDoc that represents the initial state of the object data. Custom
 	 * sync providers can override this method to provide a custom initial state.
 	 *
@@ -186,11 +196,6 @@ export class SyncProvider {
 		syncConfig: SyncConfig,
 		record: ObjectData
 	): Promise< CRDTDoc > {
-		// IMPORTANT: We use a new Yjs document so that the initial state can be
-		// applied to the "real" Yjs document as a singular update. Therefore, we
-		// don't need to wrap the changes in a transaction.
-		const initialStateDoc = new Y.Doc();
-
 		// Load the persisted document from previous sessions.
 		const persistedDoc = await this.getPersistedCRDTDoc(
 			syncConfig,
@@ -209,9 +214,16 @@ export class SyncProvider {
 
 		// Otherwise, use the current record.
 		const initialData = syncConfig.getInitialObjectData( record );
+
+		// IMPORTANT: We use a new Yjs document so that the initial state can be
+		// applied to the "real" Yjs document as a singular update. Therefore, we
+		// don't need to wrap the changes in a transaction.
+		const initialStateDoc = createYjsDoc( syncConfig.objectType );
+
 		syncConfig.applyChangesToCRDTDoc(
 			initialStateDoc,
 			initialData,
+			record,
 			'syncProvider.getInitialCRDTDoc'
 		);
 
@@ -275,7 +287,7 @@ export class SyncProvider {
 	 * @param {Partial< ObjectData >} changes    Updates to make.
 	 * @param {string}                origin     The source of change.
 	 */
-	public update(
+	public updateCRDTDoc(
 		objectType: ObjectType,
 		record: ObjectData,
 		changes: Partial< ObjectData >,
@@ -291,8 +303,36 @@ export class SyncProvider {
 		const ydoc = this.getEntityState( objectType, objectId )?.ydoc;
 
 		ydoc?.transact( () => {
-			syncConfig.applyChangesToCRDTDoc( ydoc, changes, origin );
+			syncConfig.applyChangesToCRDTDoc( ydoc, changes, record, origin );
 		}, origin );
+	}
+
+	private async updateEntityRecord(
+		syncConfig: SyncConfig,
+		handlers: RecordHandlers
+	): Promise< void > {
+		const currentRecord = await handlers.getEditedRecord();
+
+		const objectId = syncConfig.getObjectId( currentRecord );
+		const objectType = syncConfig.objectType;
+
+		const entityState = this.getEntityState( objectType, objectId );
+
+		if ( ! entityState ) {
+			return;
+		}
+
+		const { ydoc } = entityState;
+
+		// Determine which synced properties have actually changed by comparing
+		// them against the current entity record.
+		const changes = syncConfig.getChangesFromCRDTDoc( ydoc, currentRecord );
+
+		// This is a good spot to debug to see which changes are being synced. Note
+		// that `blocks` will always appear in the changes, but will only result
+		// in an update to the store if the blocks have changed.
+
+		handlers.editRecord( changes );
 	}
 
 	/**

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -12,12 +12,8 @@ export type ObjectType = string;
 export type UndoManager = Y.UndoManager;
 
 // Object data represents any entity record, post, term, user, site, etc. There
-// are not many expectations that can hold on its shape, but defining some
-// optional properties cuts down on the type narrowing.
-export interface ObjectData extends Record< string, unknown > {
-	meta?: Record< string, unknown >;
-	status?: string;
-}
+// are not many expectations that can hold on its shape.
+export interface ObjectData extends Record< string, unknown > {}
 
 export interface ConnectDocResult {
 	awareness?: Awareness;
@@ -47,6 +43,8 @@ export interface SyncConfig {
 	getInitialObjectData: ( record: ObjectData ) => ObjectData;
 	getObjectId: ( data: ObjectData ) => ObjectID;
 	objectType: ObjectType;
-	supportsAwareness?: boolean;
-	supportsUndo?: boolean;
+	supports?: {
+		awareness?: boolean;
+		undo?: boolean;
+	};
 }

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -33,6 +33,7 @@ export type ConnectDoc = (
 export interface RecordHandlers {
 	editRecord: ( data: Partial< ObjectData > ) => void;
 	getEditedRecord: () => Promise< ObjectData >;
+	refetchPersistedRecord: () => void;
 }
 
 export interface SyncConfig {

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -30,16 +30,22 @@ export type ConnectDoc = (
 	ydoc: Y.Doc
 ) => Promise< ConnectDocResult >;
 
-export type SyncConfig = {
+export interface RecordHandlers {
+	editRecord: ( data: Partial< ObjectData > ) => void;
+	getEditedRecord: () => Promise< ObjectData >;
+}
+
+export interface SyncConfig {
 	applyChangesToCRDTDoc: (
 		ydoc: Y.Doc,
-		data: Partial< ObjectData >,
+		changes: Partial< ObjectData >,
+		record: ObjectData,
 		origin: string
 	) => void;
-	fromCRDTDoc: ( ydoc: Y.Doc ) => ObjectData;
+	getChangesFromCRDTDoc: ( ydoc: Y.Doc, record: ObjectData ) => ObjectData;
 	getInitialObjectData: ( record: ObjectData ) => ObjectData;
 	getObjectId: ( data: ObjectData ) => ObjectID;
 	objectType: ObjectType;
 	supportsAwareness?: boolean;
 	supportsUndo?: boolean;
-};
+}

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import * as Y from 'yjs';
+
+/**
+ * Internal dependencies
+ */
+import { CRDT_DOC_VERSION } from './config';
+import { type ObjectType } from './types';
+
+export function createYjsDoc( objectType: ObjectType ): Y.Doc {
+	// Meta is not synced and does not get persisted with the document.
+	const meta = new Map< string, unknown >( [
+		[ 'objectType', objectType ],
+		[ 'version', CRDT_DOC_VERSION ],
+	] );
+
+	return new Y.Doc( { meta } );
+}


### PR DESCRIPTION
## What?

This PR contains [a medium-sized refactoring commit](https://github.com/Automattic/gutenberg/commit/f42a4053bedf8f6556daced9a8002e2816da82e4):

- Currently, when the sync provider receives updates from the CRDT doc, it applies every property from the `Y.Map` as an edit against the local store. With this commit, we now determine which properties have meaningfully changed (via `getChangesFromCRDTDoc`) and apply only those changed properties.
- This allows us to sync some additional properties that previously were problematic, like `status` and `excerpt`. 
- It also contains a few bug fixes for `applyChangesToCRDTDoc` and some type improvements.

It also contains [a subsequent small commit](https://github.com/Automattic/gutenberg/commit/8cd02568e8912fd043b40251f29305943f5dd125) that:

- Introduces a separate "state map" to the Yjs doc that can hold properties that do not belong to the document map. One such property is `lastPersistedAt`, which holds a timestamp indicating the last time a connected peer persisted the entity (i.e., pressed the "Save" button).
- This gives a signal to other connected peers that they should refresh their copy of the persisted entity, ensuring that _both_ the persisted entity and unsaved changes stay in sync among peers.

## Why?

Keeping the persisted entity in sync is important for certain parts of the editor UI such as the Save / Publish button and the post-publish screen. 

## Testing Instructions

**Note the companion plugin PR.**

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/887535d7-748c-4706-a6d8-7a47bd5e5706

