### PR TITLE
Add `syncedProperties` to `syncConfig`

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -295,6 +295,8 @@ async function loadPostTypeEntities() {
 			syncConfig: {
 				/**
 				 * Is syncing enabled for this entity?
+				 *
+				 * @type {boolean}
 				 */
 				enabled: Boolean(
 					postType.supports?.[ 'collaborative-editing' ] &&
@@ -368,16 +370,27 @@ async function loadPostTypeEntities() {
 
 				/**
 				 * The object type for the entity, used to scope CRDT documents.
+				 *
+				 * @type {string}
 				 */
 				objectType: `postType/${ postType.slug }`,
 
 				/**
 				 * Sync features supported by the entity.
+				 *
+				 * @type {Record< string, boolean >}
 				 */
 				supports: {
 					awareness: true,
 					undo: true,
 				},
+
+				/**
+				 * The properties that should be synced via the CRDT document.
+				 *
+				 * @type {Set< string >}
+				 */
+				syncedProperties,
 			},
 			supportsPagination: true,
 			getRevisionsUrl: ( parentId, revisionId ) =>

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -371,7 +371,7 @@ async function loadPostTypeEntities() {
 				/**
 				 * The object type for the entity, used to scope CRDT documents.
 				 *
-				 * @type {string}
+				 * @type {import('@wordpress/sync').ObjectType}
 				 */
 				objectType: `postType/${ postType.slug }`,
 

--- a/packages/sync/CODE.md
+++ b/packages/sync/CODE.md
@@ -55,5 +55,6 @@ While the Redux actions in `core-data` and the `SyncProvider` orchestrate this d
 -   `getObjectId` extracts an entity's immutable ID from an entity record.
 -   `objectType` is a unique string that identifies the entity type.
 -   `supports` is a hash that declares support for various sync features, present and future.
+-   `syncedProperties` is the set of entity properties that should be synced (possibly including computed or meta properties from `getInitialObjectData`).
 
-While an entity should internally define which of its properties are synced, that set is not exported. An entity's `syncConfig` "owns" its behavior and it should not delegate or leak that responsibility to other parts of the codebase.
+An entity's `syncConfig` "owns" the sync behavior of the entity (especially via `applyChangesToCRDTDoc` and `getChangesFromCRDTDoc`) and it should not delegate or leak that responsibility to other parts of the codebase.

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -45,4 +45,5 @@ export interface SyncConfig {
 		awareness?: boolean;
 		undo?: boolean;
 	};
+	syncedProperties: Set< string >;
 }


### PR DESCRIPTION
## What?

Add `syncedProperties` to `syncConfig` so that they can be used when evaluating whether a persisted CRDT doc should be invalidated.
