### PR TITLE
Fix awareness UI in "Show Template" mode

### DIFF
--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -104,15 +104,23 @@ export default function useBlockSync( {
 		// and so it would already be persisted.
 		__unstableMarkNextChangeAsNotPersistent();
 		if ( clientId ) {
+			const blockName = getBlockName( clientId );
+			const isPostContentBlock = blockName === 'core/post-content';
+
 			// It is important to batch here because otherwise,
 			// as soon as `setHasControlledInnerBlocks` is called
 			// the effect to restore might be triggered
 			// before the actual blocks get set properly in state.
 			registry.batch( () => {
 				setHasControlledInnerBlocks( clientId, true );
-				const storeBlocks = controlledBlocks.map( ( block ) =>
-					cloneBlock( block )
-				);
+
+				// For post-content block children, preserve the
+				// original blocks to maintain UUIDs used for
+				// multi-user collaboration
+				const storeBlocks = isPostContentBlock
+					? controlledBlocks
+					: controlledBlocks.map( ( block ) => cloneBlock( block ) );
+
 				if ( subscribedRef.current ) {
 					pendingChangesRef.current.incoming = storeBlocks;
 				}

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -117,6 +117,8 @@ export default function useBlockSync( {
 				// For post-content block children, preserve the
 				// original blocks to maintain UUIDs used for
 				// multi-user collaboration
+				//
+				// Unsure: Why are these blocks being cloned? Do they need to be?
 				const storeBlocks = isPostContentBlock
 					? controlledBlocks
 					: controlledBlocks.map( ( block ) => cloneBlock( block ) );


### PR DESCRIPTION
## What?

This modifies `useBlockSync()` to persist post content block IDs when "Show Template" mode is enabled.

## Why?

Currently, when "Show Template" mode is enabled, cursors and other block-specific awareness information doesn't sync across clients. Awareness cursors and block highlights do not show when in "Show Template" mode.

## How?

When "Show Template" is enabled, this causes all post content blocks to run through `cloneBlock()`, which gives each block a random UUID each time the mode is enabled. In our awareness implementation, we use synced block IDs to show cursor state and block highlights. Any time blocks are `cloneBlock()`ed we lose the ability to easily join block state with the awareness overlay.

In the changed code below, the `clientId` only has a value when it represents a block with an underlying controlled entity, such as a template or post content. The `clientId` passed into `useBlockSync()` is the parent block, like a `core/post-content` or template header or template footer.

For the solution, we determine if the block being synced represents post content, and if so, we keep the default UUIDs.

The way that `cloneBlock()` is currently implemented (without using the `mergeAttributes` or `newInnerBlocks` parameters), it functions entirely to recursively replace block UUIDs:

https://github.com/Automattic/gutenberg/blob/226d8d7af298526bd9b50877b08a806cdd84b7dc/packages/blocks/src/api/factory.js#L135-L159

Because we only apply this change to Yjs-synced post content and `cloneBlock()` doesn't appear to do anything other than randomize the IDs of the blocks, this allows users to use the same block IDs used in non-template mode.

## Testing Instructions

1. Use this branch (`fix/post-content-uuids-with-show-template`) along with the Gutenberg branch [`fix/redraw-cursors-on-layout-change`](https://github.com/Automattic/vip-real-time-collaboration/compare/fix/redraw-cursors-on-layout-change).
2. Open a post in two separate tabs.
3. In one tab, switch into "Show Template" mode. You should see your own cursor disappear (Gutenberg removes your selection automatically), but the other user's cursor stay in the same place.
4. Make regular changes to the post, and ensure the awareness state and cursor updates accordingly.
5. Try switching both users between template and non-template mode and ensure the editor awareness functions the same.