### PR TITLE
Update naming of record to rawRecord for clarity

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -8,13 +8,13 @@ import { capitalCase, pascalCase } from 'change-case';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import {
 	applyPostChangesToCRDTDoc,
+	getInitialPostObjectData,
 	getPostChangesFromCRDTDoc,
 	getSyncedPropertiesForPostType,
 } from './utils/crdt';
@@ -336,18 +336,12 @@ async function loadPostTypeEntities() {
 				 * @param {import('@wordpress/sync').ObjectData} record
 				 * @return {import('@wordpress/sync').ObjectData} The initial data
 				 */
-				getInitialObjectData: ( record ) => {
-					// Mix in the parsed blocks into the record. Only allow properties in
-					// the synced properties set.
-					const content = record.content?.raw ?? record.content ?? '';
-					const blocks = parse( content );
-
-					return Object.fromEntries(
-						Object.entries( { ...record, blocks } ).filter(
-							( [ key ] ) => syncedProperties.has( key )
-						)
-					);
-				},
+				getInitialObjectData: ( record ) =>
+					getInitialPostObjectData(
+						record,
+						postType,
+						syncedProperties
+					),
 
 				/**
 				 * Get the immutable identifier for an entity record.

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -27,7 +27,7 @@ const DOCUMENT_MAP_KEY = 'document';
  *
  * @param {CRDTDoc}       ydoc
  * @param {PostChanges}   changes
- * @param {Post}          record
+ * @param {Post}          rawRecord
  * @param {Type}          postType
  * @param {Set< string >} syncedProperties
  * @param {string}        origin
@@ -36,7 +36,7 @@ const DOCUMENT_MAP_KEY = 'document';
 export function applyPostChangesToCRDTDoc(
 	ydoc: CRDTDoc,
 	changes: PostChanges,
-	record: Post,
+	rawRecord: Post,
 	postType: Type,
 	syncedProperties: Set< string >,
 	origin: string
@@ -138,7 +138,7 @@ export function applyPostChangesToCRDTDoc(
 				// Undefined status indicates that we want to reset to the current
 				// persisted value.
 				if ( undefined === newStatus ) {
-					newStatus = record.status;
+					newStatus = rawRecord.status;
 				}
 
 				mergeValue( currentValue, newStatus, setValue );

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -6,6 +6,8 @@ import * as fun from 'lib0/function';
 /**
  * WordPress dependencies
  */
+// @ts-ignore No types available.
+import { parse } from '@wordpress/blocks';
 import { applyFilters } from '@wordpress/hooks';
 import { type CRDTDoc, Y } from '@wordpress/sync';
 
@@ -262,6 +264,47 @@ export function getPostChangesFromCRDTDoc(
 				}
 			}
 		} )
+	);
+}
+
+export function getInitialPostObjectData(
+	record: Post,
+	postType: Type,
+	syncedProperties: Set< string >
+): PostChanges {
+	// Mix in the parsed blocks.
+	const blocks = parse( getRawValue( record.content ) );
+
+	return Object.fromEntries(
+		Object.entries( { ...record, blocks } )
+			// Only allow properties in the synced properties set.
+			.filter( ( [ key ] ) => syncedProperties.has( key ) )
+			.map( ( [ key, value ] ) => {
+				switch ( key ) {
+					case 'content':
+					case 'excerpt':
+					case 'title': {
+						return [ key, getRawValue( value ) ];
+					}
+
+					case 'meta': {
+						return [
+							key,
+							Object.fromEntries(
+								Object.entries( value ?? {} ).filter(
+									( [ metaKey ] ) =>
+										shouldSyncMetaForPostType(
+											metaKey,
+											postType
+										)
+								)
+							),
+						];
+					}
+				}
+
+				return [ key, value ];
+			} )
 	);
 }
 

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -69,15 +69,15 @@ export class SyncProvider {
 	 * Bootstrap an entity for syncing and manage its lifecycle.
 	 *
 	 * @param {SyncConfig}     syncConfig Sync configuration for the object type.
-	 * @param {ObjectData}     record     Record representing this object type.
+	 * @param {ObjectData}     rawRecord  Raw entity record representing this object type.
 	 * @param {RecordHandlers} handlers   Handlers for updating and fetching the record.
 	 */
 	public async bootstrap(
 		syncConfig: SyncConfig,
-		record: ObjectData,
+		rawRecord: ObjectData,
 		handlers: RecordHandlers
 	): Promise< void > {
-		const objectId = syncConfig.getObjectId( record );
+		const objectId = syncConfig.getObjectId( rawRecord );
 		const objectType = syncConfig.objectType;
 		const ydoc = createYjsDoc( { objectType } );
 		const connections = await this.connect( objectId, objectType, ydoc );
@@ -122,7 +122,10 @@ export class SyncProvider {
 		);
 
 		// Get the initial document state.
-		const initialDoc = await this.getInitialCRDTDoc( syncConfig, record );
+		const initialDoc = await this.getInitialCRDTDoc(
+			syncConfig,
+			rawRecord
+		);
 
 		// Attach the update listener before applying the initial state so that
 		// we update the entity record in the local store.
@@ -188,17 +191,16 @@ export class SyncProvider {
 	 * sync providers can override this method to provide a custom initial state.
 	 *
 	 * @param {SyncConfig} syncConfig Sync configuration for the object type.
-	 * @param {ObjectData} record     Initial data to apply to the document.
+	 * @param {ObjectData} rawRecord  Initial data to apply to the document.
 	 */
 	private async getInitialCRDTDoc(
 		syncConfig: SyncConfig,
-		record: ObjectData
+		rawRecord: ObjectData
 	): Promise< CRDTDoc > {
 		// Load the persisted document from previous sessions.
 		const persistedDoc = await this.getPersistedCRDTDoc(
 			syncConfig,
-			record,
-			CRDT_DOC_VERSION
+			rawRecord
 		);
 
 		// If it exists and matches the current version, apply it as the base state
@@ -211,7 +213,7 @@ export class SyncProvider {
 		}
 
 		// Otherwise, use the current record.
-		const initialData = syncConfig.getInitialObjectData( record );
+		const initialData = syncConfig.getInitialObjectData( rawRecord );
 
 		// IMPORTANT: We use a new Yjs document so that the initial state can be
 		// applied to the "real" Yjs document as a singular update. Therefore, we
@@ -223,7 +225,7 @@ export class SyncProvider {
 		syncConfig.applyChangesToCRDTDoc(
 			initialStateDoc,
 			initialData,
-			record,
+			rawRecord,
 			LOCAL_SYNC_PROVIDER_ORIGIN
 		);
 
@@ -237,15 +239,13 @@ export class SyncProvider {
 	 * entity. Custom sync providers can override this method to provide their
 	 * implementation.
 	 *
-	 * @param {SyncConfig}            _syncConfig Sync configuration for the object type.
-	 * @param {ObjectData}            _record     Record representing this object type.
-	 * @param {Partial< ObjectData >} _changes    Updates to make.
+	 * @param {SyncConfig} _syncConfig Sync configuration for the object type.
+	 * @param {ObjectData} _rawRecord  Raw record representing this object type.
 	 * @return {Promise< Record< string, any > >} Entity meta.
 	 */
 	public async createEntityMeta(
 		_syncConfig: SyncConfig,
-		_record: ObjectData,
-		_changes: Partial< ObjectData >
+		_rawRecord: ObjectData
 	): Promise< Record< string, any > > {
 		return Promise.resolve( {} );
 	}
@@ -255,15 +255,13 @@ export class SyncProvider {
 	 * Custom sync providers can override this method to provide their
 	 * implementation.
 	 *
-	 * @param {SyncConfig} _syncConfig      Sync configuration for the object type.
-	 * @param {ObjectData} _record          Record representing this object type.
-	 * @param {number}     _expectedVersion Expected version of persisted CRDT document.
+	 * @param {SyncConfig} _syncConfig Sync configuration for the object type.
+	 * @param {ObjectData} _rawRecord  Record representing this object type.
 	 * @return {Promise< CRDTDoc | null >} The persisted CRDT document, or null if none exists.
 	 */
 	protected async getPersistedCRDTDoc(
 		_syncConfig: SyncConfig,
-		_record: ObjectData,
-		_expectedVersion: number
+		_rawRecord: ObjectData
 	): Promise< CRDTDoc | null > {
 		return Promise.resolve( null );
 	}
@@ -283,23 +281,28 @@ export class SyncProvider {
 	 * Update CRDT document with changes from the local store.
 	 *
 	 * @param {SyncConfig}            syncConfig Sync configuration for the object type.
-	 * @param {ObjectData}            record     Record to load.
+	 * @param {ObjectData}            rawRecord  Raw record to load.
 	 * @param {Partial< ObjectData >} changes    Updates to make.
 	 * @param {string}                origin     The source of change.
 	 */
 	public updateCRDTDoc(
 		syncConfig: SyncConfig,
-		record: ObjectData,
+		rawRecord: ObjectData,
 		changes: Partial< ObjectData >,
 		origin: string
 	): void {
 		const objectType = syncConfig.objectType;
-		const objectId = syncConfig.getObjectId( record );
+		const objectId = syncConfig.getObjectId( rawRecord );
 		const entityId = this.getEntityId( objectType, objectId );
 		const ydoc = this.entityStates.get( entityId )?.ydoc;
 
 		ydoc?.transact( () => {
-			syncConfig.applyChangesToCRDTDoc( ydoc, changes, record, origin );
+			syncConfig.applyChangesToCRDTDoc(
+				ydoc,
+				changes,
+				rawRecord,
+				origin
+			);
 		}, origin );
 	}
 
@@ -355,13 +358,13 @@ export class SyncProvider {
 	 * used by peers as a signal that they need to refetch the persisted entity.
 	 *
 	 * @param {SyncConfig} syncConfig Sync configuration for the object type.
-	 * @param {ObjectData} record     Record representing this object type.
+	 * @param {ObjectData} rawRecord  Raw record representing this object type.
 	 */
 	public updateLastPersistedDate(
 		syncConfig: SyncConfig,
-		record: ObjectData
+		rawRecord: ObjectData
 	): void {
-		const objectId = syncConfig.getObjectId( record );
+		const objectId = syncConfig.getObjectId( rawRecord );
 		const objectType = syncConfig.objectType;
 		const entityId = this.getEntityId( objectType, objectId );
 		const entityState = this.entityStates.get( entityId );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -34,7 +34,7 @@ export interface SyncConfig {
 	applyChangesToCRDTDoc: (
 		ydoc: Y.Doc,
 		changes: Partial< ObjectData >,
-		record: ObjectData,
+		rawRecord: ObjectData,
 		origin: string
 	) => void;
 	getChangesFromCRDTDoc: ( ydoc: Y.Doc, record: ObjectData ) => ObjectData;


### PR DESCRIPTION

## What?
Update naming of record to rawRecord for clarity. Small companion improvement to https://github.com/Automattic/vip-real-time-collaboration/pull/30

> In an ideal world, we would have generic types that would help us distinguish between a "raw record" and syncable "object data." For now, we will rename the variables as a primitive signal to help avoid these bad assumptions in the future.:
