### PR TITLE
Create dedicated getInitialPostObjectData alongside similar functions

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -8,13 +8,13 @@ import { capitalCase, pascalCase } from 'change-case';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import {
 	applyPostChangesToCRDTDoc,
+	getInitialPostObjectData,
 	getPostChangesFromCRDTDoc,
 	getSyncedPropertiesForPostType,
 } from './utils/crdt';
@@ -336,18 +336,12 @@ async function loadPostTypeEntities() {
 				 * @param {import('@wordpress/sync').ObjectData} record
 				 * @return {import('@wordpress/sync').ObjectData} The initial data
 				 */
-				getInitialObjectData: ( record ) => {
-					// Mix in the parsed blocks into the record. Only allow properties in
-					// the synced properties set.
-					const content = record.content?.raw ?? record.content ?? '';
-					const blocks = parse( content );
-
-					return Object.fromEntries(
-						Object.entries( { ...record, blocks } ).filter(
-							( [ key ] ) => syncedProperties.has( key )
-						)
-					);
-				},
+				getInitialObjectData: ( record ) =>
+					getInitialPostObjectData(
+						record,
+						postType,
+						syncedProperties
+					),
 
 				/**
 				 * Get the immutable identifier for an entity record.

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -6,6 +6,8 @@ import * as fun from 'lib0/function';
 /**
  * WordPress dependencies
  */
+// @ts-ignore No types available.
+import { parse } from '@wordpress/blocks';
 import { applyFilters } from '@wordpress/hooks';
 import { type CRDTDoc, Y } from '@wordpress/sync';
 
@@ -262,6 +264,47 @@ export function getPostChangesFromCRDTDoc(
 				}
 			}
 		} )
+	);
+}
+
+export function getInitialPostObjectData(
+	record: Post,
+	postType: Type,
+	syncedProperties: Set< string >
+): PostChanges {
+	// Mix in the parsed blocks.
+	const blocks = parse( getRawValue( record.content ) );
+
+	return Object.fromEntries(
+		Object.entries( { ...record, blocks } )
+			// Only allow properties in the synced properties set.
+			.filter( ( [ key ] ) => syncedProperties.has( key ) )
+			.map( ( [ key, value ] ) => {
+				switch ( key ) {
+					case 'content':
+					case 'excerpt':
+					case 'title': {
+						return [ key, getRawValue( value ) ];
+					}
+
+					case 'meta': {
+						return [
+							key,
+							Object.fromEntries(
+								Object.entries( value ?? {} ).filter(
+									( [ metaKey ] ) =>
+										shouldSyncMetaForPostType(
+											metaKey,
+											postType
+										)
+								)
+							),
+						];
+					}
+				}
+
+				return [ key, value ];
+			} )
 	);
 }
 


### PR DESCRIPTION
## What?

Create dedicated `getInitialPostObjectData` alongside similar functions. Companion fix to https://github.com/Automattic/vip-real-time-collaboration/pull/30 to ensure that "raw" fields are extracted and that unsynced meta is excluded.
