### PR TITLE
Allow post lock dialog to return and retain functionality

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -148,6 +148,10 @@ function PostLockedModal() {
 		return null;
 	}
 
+	if ( window.__experimentalEnableSync ) {
+		return null;
+	}
+
 	const userDisplayName = user.name;
 	const userAvatar = user.avatar;
 

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -148,6 +148,7 @@ function PostLockedModal() {
 		return null;
 	}
 
+	// Potentially refactor this into the above shortcircuit (!isLocked).
 	if ( window.__experimentalEnableSync ) {
 		return null;
 	}


### PR DESCRIPTION
## What?

Directly overrides post lock modal and returns when in experimental sync (collaborative editing) mode.

## Why?
In https://github.com/Automattic/vip-real-time-collaboration/pull/6 we introduced a method to override the post lock modal, but this resulted in the functionality within the post lock modal being lost also.

## How?
Returns early on setting check.

## Testing Instructions

1. Open post with at least 2 users.
2. Observe that no modal is show.