### PR TITLE
Supply `Awareness` instance to connection and observe changes

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -160,6 +160,10 @@ export const getEntityRecord =
 						{
 							// Handle edits sourced from the sync provider.
 							editRecord: ( edits ) => {
+								if ( ! Object.keys( edits ).length ) {
+									return;
+								}
+
 								dispatch( {
 									type: 'EDIT_ENTITY_RECORD',
 									kind,

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -9,7 +9,7 @@ import * as fun from 'lib0/function';
 // @ts-ignore No types available.
 import { parse } from '@wordpress/blocks';
 import { applyFilters } from '@wordpress/hooks';
-import { type CRDTDoc, Y } from '@wordpress/sync';
+import { type CRDTDoc, CRDT_RECORD_MAP_KEY, Y } from '@wordpress/sync';
 
 /**
  * Internal dependencies
@@ -19,9 +19,6 @@ import { type Post } from '../entity-types/post';
 import { type Type } from '../entity-types';
 
 type PostChanges = Partial< Post > & { blocks?: Block[] };
-
-// Key used to store the document map in the Y.Doc.
-const DOCUMENT_MAP_KEY = 'document';
 
 /**
  * Given a set of local changes to a post record, apply those changes to the
@@ -43,7 +40,7 @@ export function applyPostChangesToCRDTDoc(
 	syncedProperties: Set< string >,
 	origin: string
 ): void {
-	const ymap = ydoc.getMap( DOCUMENT_MAP_KEY );
+	const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
 
 	Object.entries( changes ).forEach( ( [ key, newValue ] ) => {
 		if ( ! syncedProperties.has( key ) ) {
@@ -188,7 +185,7 @@ export function getPostChangesFromCRDTDoc(
 	postType: Type,
 	syncedProperties: Set< string >
 ): PostChanges {
-	const ymap = ydoc.getMap( DOCUMENT_MAP_KEY );
+	const ymap = ydoc.getMap( CRDT_RECORD_MAP_KEY );
 
 	return Object.fromEntries(
 		Object.entries( ymap.toJSON() ).filter( ( [ key, newValue ] ) => {

--- a/packages/sync/src/config.ts
+++ b/packages/sync/src/config.ts
@@ -9,11 +9,11 @@ export const CRDT_STATE_MAP_KEY = 'state';
 
 // Sub-keys.
 export const CRDT_STATE_PERSISTED_AT_KEY = 'persistedAt';
+export const CRDT_STATE_PERSISTED_BY_KEY = 'persistedBy';
+export const CRDT_STATE_RESTORED_AT_KEY = 'restoredAt';
+export const CRDT_STATE_RESTORED_BY_KEY = 'restoredBy';
+export const CRDT_STATE_VERSION_KEY = 'version';
 
 // Origin strings.
 export const LOCAL_EDITOR_ORIGIN = 'gutenberg';
 export const LOCAL_SYNC_PROVIDER_ORIGIN = 'syncProvider';
-export const LOCAL_ORIGINS = [
-	LOCAL_EDITOR_ORIGIN,
-	LOCAL_SYNC_PROVIDER_ORIGIN,
-];

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -10,7 +10,7 @@ import { createWebRTCConnection } from './create-webrtc-connection';
 import { SyncProvider } from './provider';
 
 export * as Y from 'yjs';
-export { CRDT_DOC_VERSION } from './config';
+export * from './config';
 export { connectIndexDb } from './connect-indexdb';
 export { createWebRTCConnection } from './create-webrtc-connection';
 export { SyncProvider } from './provider';

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -2,15 +2,19 @@
  * External dependencies
  */
 import * as Y from 'yjs';
+import { Awareness } from 'y-protocols/awareness';
 
 /**
  * Internal dependencies
  */
 import {
 	CRDT_DOC_VERSION,
-	CRDT_STATE_MAP_KEY,
-	CRDT_STATE_PERSISTED_AT_KEY,
-	LOCAL_ORIGINS,
+	CRDT_RECORD_MAP_KEY as RECORD_KEY,
+	CRDT_STATE_MAP_KEY as STATE_KEY,
+	CRDT_STATE_PERSISTED_AT_KEY as PERSISTED_AT_KEY,
+	CRDT_STATE_PERSISTED_BY_KEY as PERSISTED_BY_KEY,
+	CRDT_STATE_RESTORED_AT_KEY as RESTORED_AT_KEY,
+	CRDT_STATE_RESTORED_BY_KEY as RESTORED_BY_KEY,
 	LOCAL_SYNC_PROVIDER_ORIGIN,
 } from './config';
 import type {
@@ -28,9 +32,10 @@ import { UndoManager } from './undo-manager';
 import { createYjsDoc } from './utils';
 
 interface EntityState {
+	awareness?: Awareness;
 	discard: () => void;
 	handlers: RecordHandlers;
-	lastPersistedAt: number;
+	objectId: ObjectID;
 	syncConfig: SyncConfig;
 	undoManager?: UndoManager;
 	ydoc: CRDTDoc;
@@ -53,7 +58,6 @@ export class SyncProvider {
 	 */
 	private undoManager: UndoManager | undefined;
 
-	protected connections: Map< EntityID, ConnectDocResult[] > = new Map();
 	protected entityStates: Map< EntityID, EntityState > = new Map();
 
 	/**
@@ -77,59 +81,85 @@ export class SyncProvider {
 		rawRecord: ObjectData,
 		handlers: RecordHandlers
 	): Promise< void > {
+		const now = Date.now();
 		const objectId = syncConfig.getObjectId( rawRecord );
 		const objectType = syncConfig.objectType;
 		const ydoc = createYjsDoc( { objectType } );
-		const connections = await this.connect( objectId, objectType, ydoc );
 		const entityId = this.getEntityId( objectType, objectId );
+
+		const recordMap = ydoc.getMap( RECORD_KEY );
+		const stateMap = ydoc.getMap( STATE_KEY );
 
 		// Clean up connections and in-memory state when the entity is discarded.
 		const onDiscard = (): void => {
 			connections.forEach( ( result ) => result.destroy() );
-			ydoc.off( 'update', onUpdate );
+			recordMap.unobserveDeep( onRecordUpdate );
+			stateMap.unobserve( onStateUpdate );
 			ydoc.destroy();
-			this.connections.delete( entityId );
 			this.entityStates.delete( entityId );
 		};
 
 		// When the CRDT document is updated by a connection (not a local origin like
 		// Gutenberg or this SyncProvider), update the local store.
-		const onUpdate = ( _update: Uint8Array, origin: string ): void => {
-			if ( LOCAL_ORIGINS.includes( origin ) ) {
+		const onRecordUpdate = (
+			_events: Y.YEvent< any >[],
+			transaction: Y.Transaction
+		): void => {
+			if ( transaction.local ) {
 				return;
 			}
 
 			void this.updateEntityRecord( objectType, objectId );
 		};
 
+		const onStateUpdate = (
+			event: Y.YMapEvent< unknown >,
+			transaction: Y.Transaction
+		) => {
+			if ( transaction.local ) {
+				return;
+			}
+
+			if ( ! event.keysChanged.has( PERSISTED_AT_KEY ) ) {
+				return;
+			}
+
+			const newValue = stateMap.get( PERSISTED_AT_KEY );
+			if ( 'number' === typeof newValue && newValue > now ) {
+				handlers.refetchPersistedRecord();
+			}
+		};
+
 		const entityState: EntityState = {
 			discard: onDiscard,
 			handlers,
-			lastPersistedAt: Date.now(),
+			objectId,
 			syncConfig,
 			ydoc,
 		};
+
+		if ( syncConfig.supports?.awareness ) {
+			entityState.awareness = new Awareness( ydoc );
+		}
 
 		if ( syncConfig.supports?.undo ) {
 			entityState.undoManager = new UndoManager( ydoc );
 			this.undoManager = entityState.undoManager;
 		}
 
-		this.connections.set( entityId, connections );
-		this.entityStates.set(
-			this.getEntityId( objectType, objectId ),
-			entityState
-		);
+		this.entityStates.set( entityId, entityState );
+
+		const connections = await this.connect( entityState );
+
+		// Attach observers.
+		recordMap.observeDeep( onRecordUpdate );
+		stateMap.observe( onStateUpdate );
 
 		// Get the initial document state.
 		const initialDoc = await this.getInitialCRDTDoc(
 			syncConfig,
 			rawRecord
 		);
-
-		// Attach the update listener before applying the initial state so that
-		// we update the entity record in the local store.
-		ydoc.on( 'update', onUpdate );
 
 		// Apply the initial document to the current document as a singular update.
 		if ( initialDoc ) {
@@ -139,7 +169,7 @@ export class SyncProvider {
 					Y.applyUpdate( ydoc, Y.encodeStateAsUpdate( initialDoc ) );
 				},
 				LOCAL_SYNC_PROVIDER_ORIGIN,
-				false
+				true
 			);
 		}
 
@@ -153,6 +183,9 @@ export class SyncProvider {
 						rawRecord,
 						LOCAL_SYNC_PROVIDER_ORIGIN
 					);
+
+					stateMap.set( RESTORED_AT_KEY, Date.now() );
+					stateMap.set( RESTORED_BY_KEY, ydoc.clientID );
 				},
 				LOCAL_SYNC_PROVIDER_ORIGIN,
 				true
@@ -179,18 +212,19 @@ export class SyncProvider {
 	/**
 	 * Establish connections for the given entity and its Yjs document.
 	 *
-	 * @param {ObjectID}   objectId   Object ID to connect.
-	 * @param {ObjectType} objectType Object type to connect.
-	 * @param {CRDTDoc}    ydoc       Yjs document for the object.
+	 * @param {EntityState} entityState State for the entity.
 	 */
 	private async connect(
-		objectId: ObjectID,
-		objectType: ObjectType,
-		ydoc: CRDTDoc
+		entityState: EntityState
 	): Promise< ConnectDocResult[] > {
 		return await Promise.all(
 			this.connectionCreators?.map( ( create ) =>
-				create( objectId, objectType, ydoc )
+				create(
+					entityState.objectId,
+					entityState.syncConfig.objectType,
+					entityState.ydoc,
+					entityState.awareness
+				)
 			)
 		);
 	}
@@ -243,7 +277,7 @@ export class SyncProvider {
 			return null;
 		}
 
-		const stateMap = persistedDoc.getMap( CRDT_STATE_MAP_KEY );
+		const stateMap = persistedDoc.getMap( STATE_KEY );
 
 		if ( CRDT_DOC_VERSION !== stateMap.get( 'version' ) ) {
 			// TODO: Implement version migration. We have not yet incremented the
@@ -369,7 +403,7 @@ export class SyncProvider {
 			return;
 		}
 
-		const { handlers, lastPersistedAt, syncConfig, ydoc } = entityState;
+		const { handlers, syncConfig, ydoc } = entityState;
 
 		const currentRecord = await handlers.getEditedRecord();
 
@@ -382,20 +416,6 @@ export class SyncProvider {
 		// in an update to the store if the blocks have changed.
 
 		handlers.editRecord( changes );
-
-		// Determine if we should refetch the persisted entity record from the
-		// REST API because another client has persisted changes.
-		const ystateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
-		const persistedAt =
-			( ystateMap.get( CRDT_STATE_PERSISTED_AT_KEY ) as number ) ?? 0;
-		if ( persistedAt > lastPersistedAt ) {
-			this.entityStates.set( entityId, {
-				...entityState,
-				lastPersistedAt: persistedAt,
-			} );
-
-			void handlers.refetchPersistedRecord();
-		}
 	}
 
 	/**
@@ -419,19 +439,13 @@ export class SyncProvider {
 		}
 
 		const ydoc = entityState.ydoc;
-		const lastPersistedAt = Date.now();
-
-		// Update in-memory state.
-		this.entityStates.set( entityId, {
-			...entityState,
-			lastPersistedAt,
-		} );
 
 		Y.transact(
 			ydoc,
 			() => {
-				const stateMap = ydoc.getMap( 'state' );
-				stateMap.set( CRDT_STATE_PERSISTED_AT_KEY, lastPersistedAt );
+				const stateMap = ydoc.getMap( STATE_KEY );
+				stateMap.set( PERSISTED_AT_KEY, Date.now() );
+				stateMap.set( PERSISTED_BY_KEY, ydoc.clientID );
 			},
 			LOCAL_SYNC_PROVIDER_ORIGIN,
 			true

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -99,13 +99,16 @@ export class SyncProvider {
 			this.entityStates.delete( entityId );
 		};
 
-		// When the CRDT document is updated by a connection (not a local origin like
-		// Gutenberg or this SyncProvider), update the local store.
+		// When the CRDT document is updated by the UndoManager or a connection (not
+		// a local origin), update the local store.
 		const onRecordUpdate = (
 			_events: Y.YEvent< any >[],
 			transaction: Y.Transaction
 		): void => {
-			if ( transaction.local ) {
+			if (
+				transaction.local &&
+				! ( transaction.origin instanceof Y.UndoManager )
+			) {
 				return;
 			}
 

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -163,33 +163,23 @@ export class SyncProvider {
 
 		// Apply the initial document to the current document as a singular update.
 		if ( initialDoc ) {
-			Y.transact(
-				ydoc,
-				() => {
-					Y.applyUpdate( ydoc, Y.encodeStateAsUpdate( initialDoc ) );
-				},
-				LOCAL_SYNC_PROVIDER_ORIGIN,
-				true
-			);
+			ydoc.transact( () => {
+				Y.applyUpdate( ydoc, Y.encodeStateAsUpdate( initialDoc ) );
+			}, LOCAL_SYNC_PROVIDER_ORIGIN );
 		}
 
 		if ( ! initialDoc || true === initialDoc?.meta?.get( 'invalidated' ) ) {
-			Y.transact(
-				ydoc,
-				() => {
-					syncConfig.applyChangesToCRDTDoc(
-						ydoc,
-						syncConfig.getInitialObjectData( rawRecord ),
-						rawRecord,
-						LOCAL_SYNC_PROVIDER_ORIGIN
-					);
+			ydoc.transact( () => {
+				syncConfig.applyChangesToCRDTDoc(
+					ydoc,
+					syncConfig.getInitialObjectData( rawRecord ),
+					rawRecord,
+					LOCAL_SYNC_PROVIDER_ORIGIN
+				);
 
-					stateMap.set( RESTORED_AT_KEY, Date.now() );
-					stateMap.set( RESTORED_BY_KEY, ydoc.clientID );
-				},
-				LOCAL_SYNC_PROVIDER_ORIGIN,
-				true
-			);
+				stateMap.set( RESTORED_AT_KEY, Date.now() );
+				stateMap.set( RESTORED_BY_KEY, ydoc.clientID );
+			}, LOCAL_SYNC_PROVIDER_ORIGIN );
 
 			// TODO: This new state should be persisted to the entity record. This
 			// will result in a "dirty" record, but if the user does not save the
@@ -440,15 +430,10 @@ export class SyncProvider {
 
 		const ydoc = entityState.ydoc;
 
-		Y.transact(
-			ydoc,
-			() => {
-				const stateMap = ydoc.getMap( STATE_KEY );
-				stateMap.set( PERSISTED_AT_KEY, Date.now() );
-				stateMap.set( PERSISTED_BY_KEY, ydoc.clientID );
-			},
-			LOCAL_SYNC_PROVIDER_ORIGIN,
-			true
-		);
+		ydoc.transact( () => {
+			const stateMap = ydoc.getMap( STATE_KEY );
+			stateMap.set( PERSISTED_AT_KEY, Date.now() );
+			stateMap.set( PERSISTED_BY_KEY, ydoc.clientID );
+		}, LOCAL_SYNC_PROVIDER_ORIGIN );
 	}
 }

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -14,14 +14,14 @@ export type ObjectType = string;
 export interface ObjectData extends Record< string, unknown > {}
 
 export interface ConnectDocResult {
-	awareness?: Awareness;
 	destroy: () => void;
 }
 
 export type ConnectDoc = (
 	id: ObjectID,
 	type: ObjectType,
-	ydoc: Y.Doc
+	ydoc: Y.Doc,
+	awareness?: Awareness
 ) => Promise< ConnectDocResult >;
 
 export interface RecordHandlers {

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -6,7 +6,13 @@ import * as Y from 'yjs';
 /**
  * Internal dependencies
  */
-import { CRDT_DOC_VERSION, CRDT_STATE_MAP_KEY } from './config';
+import {
+	CRDT_DOC_VERSION,
+	CRDT_STATE_MAP_KEY,
+	CRDT_STATE_PERSISTED_AT_KEY,
+	CRDT_STATE_RESTORED_AT_KEY,
+	CRDT_STATE_VERSION_KEY,
+} from './config';
 
 export function createYjsDoc( documentMeta: Record< string, unknown > ): Y.Doc {
 	// Meta is not synced and does not get persisted with the document.
@@ -17,7 +23,9 @@ export function createYjsDoc( documentMeta: Record< string, unknown > ): Y.Doc {
 	const ydoc = new Y.Doc( { meta: metaMap } );
 	const stateMap = ydoc.getMap( CRDT_STATE_MAP_KEY );
 
-	stateMap.set( 'version', CRDT_DOC_VERSION );
+	stateMap.set( CRDT_STATE_PERSISTED_AT_KEY, 0 );
+	stateMap.set( CRDT_STATE_RESTORED_AT_KEY, 0 );
+	stateMap.set( CRDT_STATE_VERSION_KEY, CRDT_DOC_VERSION );
 
 	return ydoc;
 }


### PR DESCRIPTION
## What?

Three related changes here:

1. Put `SyncProvider` in control of creating the `Awareness` instance (if supported) and store on entity state. This will be needed as we incorporate awareness / presence features from our plugin. Passing the awareness instance to the connection function gives extenders access to it early, which is needed to catch events that happen on connection or soon after.
2. Move to `.observe` / `.observeDeep` listeners for each root-level CRDT map instead of a single global `.on( 'update' )` listener. This allows us to organize our listener code and provides better performance.
3. The listener change above allows us to store all of our state signals in the state map. However, Yjs listeners do not tell us which peer was responsible for the change. So we need to add the client IDs of the current actor to the state map.