### PR TITLE
Use YMultiDocUndoManager

### DIFF
--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -37,26 +37,12 @@ interface EntityState {
 	handlers: RecordHandlers;
 	objectId: ObjectID;
 	syncConfig: SyncConfig;
-	undoManager?: UndoManager;
 	ydoc: CRDTDoc;
 }
 
 export class SyncProvider {
 	private connectionCreators: ConnectDoc[];
-
-	/**
-	 * CAUTION: We currently store a single UndoManager instance under these
-	 * assumptions:
-	 *
-	 * 1. Only entities loaded by the block editor support an undo manager.
-	 * 2. Only one such entity is loaded at a time.
-	 * 3. The entity's SyncConfig has `supports.undo` set to true.
-	 *
-	 * If these assumptions fail, we will need to refactor the selectors provided
-	 * by `@wordpress/core-data` (e.g., `getUndoManager`) to support multiple
-	 * UndoManager instances by requiring the entity type and ID as parameters.
-	 */
-	private undoManager: UndoManager | undefined;
+	private undoManager: UndoManager;
 
 	protected entityStates: Map< EntityID, EntityState > = new Map();
 
@@ -67,6 +53,7 @@ export class SyncProvider {
 	 */
 	public constructor( connectionCreators: ConnectDoc[] = [] ) {
 		this.connectionCreators = connectionCreators;
+		this.undoManager = UndoManager.create();
 	}
 
 	/**
@@ -146,8 +133,7 @@ export class SyncProvider {
 		}
 
 		if ( syncConfig.supports?.undo ) {
-			entityState.undoManager = new UndoManager( ydoc );
-			this.undoManager = entityState.undoManager;
+			this.undoManager.addToScope( recordMap );
 		}
 
 		this.entityStates.set( entityId, entityState );

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -82,11 +82,6 @@ export class SyncProvider {
 			connections.forEach( ( result ) => result.destroy() );
 			recordMap.unobserveDeep( onRecordUpdate );
 			stateMap.unobserve( onStateUpdate );
-
-			if ( syncConfig.supports?.undo ) {
-				this.undoManager.untrackDoc( ydoc );
-			}
-
 			ydoc.destroy();
 			this.entityStates.delete( entityId );
 		};
@@ -138,7 +133,6 @@ export class SyncProvider {
 		}
 
 		if ( syncConfig.supports?.undo ) {
-			this.undoManager.trackDoc( ydoc );
 			this.undoManager.addToScope( recordMap );
 		}
 

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -82,6 +82,11 @@ export class SyncProvider {
 			connections.forEach( ( result ) => result.destroy() );
 			recordMap.unobserveDeep( onRecordUpdate );
 			stateMap.unobserve( onStateUpdate );
+
+			if ( syncConfig.supports?.undo ) {
+				this.undoManager.untrackDoc( ydoc );
+			}
+
 			ydoc.destroy();
 			this.entityStates.delete( entityId );
 		};
@@ -133,6 +138,7 @@ export class SyncProvider {
 		}
 
 		if ( syncConfig.supports?.undo ) {
+			this.undoManager.trackDoc( ydoc );
 			this.undoManager.addToScope( recordMap );
 		}
 

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -73,11 +73,6 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 	 */
 	public addToScope( ymap: Y.Map< any > ): void {
 		this.undoManager.addToScope( ymap );
-		this.undoManager.addTrackedOrigin( ymap.doc?.clientID );
-
-		ymap.doc?.on( 'destroy', () => {
-			this.undoManager.removeTrackedOrigin( ymap.doc?.clientID );
-		} );
 	}
 
 	/**

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -35,10 +35,6 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 			// Ensure that we only scope the undo/redo to the current editor.
 			// The yjs document's clientID is added once it's available.
 			trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
-			// Do not ignore changes that come from remote clients.
-			// This is to account for other clients making changes to the same
-			// block.
-			ignoreRemoteMapChanges: true,
 		} );
 	}
 

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import * as Y from 'yjs';
+import type * as Y from 'yjs';
 
 /**
  * WordPress dependencies
@@ -14,26 +14,35 @@ import type {
 /**
  * Internal dependencies
  */
-import type { CRDTDoc, ObjectData } from './types';
+import { LOCAL_EDITOR_ORIGIN } from './config';
+import { YMultiDocUndoManager } from './y-utilities/y-multidoc-undomanager';
+import type { ObjectData } from './types';
 
 /**
- * Wrapper class that provides the WordPress UndoManager interface while using Y.UndoManager internally.
- * This allows seamless integration between Yjs collaborative editing and WordPress undo/redo functionality.
+ * Wrapper class that implements the WordPress UndoManager interface while using
+ * YMultiDocUndoManager internally. This allows undo/redo operations to be
+ * transacted against multiple CRDT documents (one per entity) and giving each
+ * peer their own undo/redo stack without conflicts.
  */
 export class UndoManager implements WPUndoManager< ObjectData > {
-	private undoManager: Y.UndoManager;
+	private static instance: UndoManager;
+	private undoManager: YMultiDocUndoManager;
 
-	public constructor( ydoc: CRDTDoc ) {
-		this.undoManager = new Y.UndoManager( ydoc.getMap( 'document' ), {
-			// Ensure we undo and redo one character at a time.
-			captureTimeout: 0,
-			// Ensure that we only scope the undo/redo to the current client, and Gutenberg origins.
-			// ToDo: Keep an eye on this, as it needs to be battle tested.
-			trackedOrigins: new Set( [ 'gutenberg', ydoc.clientID ] ),
-			// This ensures that are able to improve the client specific undo/redo experience.
-			// This reduces the bugs we see, but it doesn't eliminate them entirely.
-			ignoreRemoteMapChanges: true,
+	private constructor() {
+		this.undoManager = new YMultiDocUndoManager( [], {
+			// Throttle undo/redo captures. (default: 500ms)
+			captureTimeout: 250,
+			// Ensure that we only scope the undo/redo to the current editor.
+			trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
 		} );
+	}
+
+	public static create(): UndoManager {
+		if ( ! UndoManager.instance ) {
+			UndoManager.instance = new UndoManager();
+		}
+
+		return UndoManager.instance;
 	}
 
 	/**
@@ -53,9 +62,17 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 	}
 
 	/**
+	 * Add a Yjs map to the scope of the undo manager.
+	 *
+	 * @param {Y.Map< any >} ymap The Yjs map to add to the scope.
+	 */
+	public addToScope( ymap: Y.Map< any > ): void {
+		this.undoManager.addToScope( ymap );
+	}
+
+	/**
 	 * Undo the last recorded changes.
 	 *
-	 * @return The undone record or undefined if nothing to undo.
 	 */
 	public undo(): HistoryRecord< ObjectData > | undefined {
 		if ( ! this.hasUndo() ) {
@@ -65,14 +82,13 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 		// Perform the undo operation
 		this.undoManager.undo();
 
-		// @TODO See if the undo operation can return a record from Yjs.
+		// Intentionally return an empty array, because the SyncProvider will update
+		// the entity record based on the Yjs document changes.
 		return [];
 	}
 
 	/**
 	 * Redo the last undone changes.
-	 *
-	 * @return The redone record or undefined if nothing to redo.
 	 */
 	public redo(): HistoryRecord< ObjectData > | undefined {
 		if ( ! this.hasRedo() ) {
@@ -82,7 +98,8 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 		// Perform the redo operation
 		this.undoManager.redo();
 
-		// @TODO See if the redo operation can return a record from Yjs.
+		// Intentionally return an empty array, because the SyncProvider will update
+		// the entity record based on the Yjs document changes.
 		return [];
 	}
 

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -31,7 +31,7 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 	private constructor() {
 		this.undoManager = new YMultiDocUndoManager( [], {
 			// Throttle undo/redo captures. (default: 500ms)
-			captureTimeout: 250,
+			captureTimeout: 200,
 			// Ensure that we only scope the undo/redo to the current editor.
 			// The yjs document's clientID is added once it's available.
 			trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -73,28 +73,11 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 	 */
 	public addToScope( ymap: Y.Map< any > ): void {
 		this.undoManager.addToScope( ymap );
-	}
+		this.undoManager.addTrackedOrigin( ymap.doc?.clientID );
 
-	/**
-	 * Add a Yjs document's origin to be tracked by the undo manager.
-	 *
-	 * This is necessary for a client specific undo/redo stack.
-	 *
-	 * @param doc The Yjs document to track.
-	 */
-	public trackDoc( doc: Y.Doc ): void {
-		this.undoManager.addTrackedOrigin( doc.clientID );
-	}
-
-	/**
-	 * Remove a Yjs document's origin from being tracked by the undo manager.
-	 *
-	 * This is necessary when the yjs document has been destroyed.
-	 *
-	 * @param doc The Yjs document to stop tracking.
-	 */
-	public untrackDoc( doc: Y.Doc ): void {
-		this.undoManager.removeTrackedOrigin( doc.clientID );
+		ymap.doc?.on( 'destroy', () => {
+			this.undoManager.removeTrackedOrigin( ymap.doc?.clientID );
+		} );
 	}
 
 	/**

--- a/packages/sync/src/undo-manager.ts
+++ b/packages/sync/src/undo-manager.ts
@@ -33,7 +33,12 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 			// Throttle undo/redo captures. (default: 500ms)
 			captureTimeout: 250,
 			// Ensure that we only scope the undo/redo to the current editor.
+			// The yjs document's clientID is added once it's available.
 			trackedOrigins: new Set( [ LOCAL_EDITOR_ORIGIN ] ),
+			// Do not ignore changes that come from remote clients.
+			// This is to account for other clients making changes to the same
+			// block.
+			ignoreRemoteMapChanges: true,
 		} );
 	}
 
@@ -68,6 +73,28 @@ export class UndoManager implements WPUndoManager< ObjectData > {
 	 */
 	public addToScope( ymap: Y.Map< any > ): void {
 		this.undoManager.addToScope( ymap );
+	}
+
+	/**
+	 * Add a Yjs document's origin to be tracked by the undo manager.
+	 *
+	 * This is necessary for a client specific undo/redo stack.
+	 *
+	 * @param doc The Yjs document to track.
+	 */
+	public trackDoc( doc: Y.Doc ): void {
+		this.undoManager.addTrackedOrigin( doc.clientID );
+	}
+
+	/**
+	 * Remove a Yjs document's origin from being tracked by the undo manager.
+	 *
+	 * This is necessary when the yjs document has been destroyed.
+	 *
+	 * @param doc The Yjs document to stop tracking.
+	 */
+	public untrackDoc( doc: Y.Doc ): void {
+		this.undoManager.removeTrackedOrigin( doc.clientID );
 	}
 
 	/**

--- a/packages/sync/src/y-utilities/LICENSE
+++ b/packages/sync/src/y-utilities/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 Kevin Jahns <kevin.jahns@protonmail.com>.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sync/src/y-utilities/y-multidoc-undomanager.js
+++ b/packages/sync/src/y-utilities/y-multidoc-undomanager.js
@@ -1,0 +1,190 @@
+// File copied as is from the y-utilities package.
+/* eslint-disable eslint-comments/disable-enable-pair */
+/* eslint-disable eslint-comments/no-unlimited-disable */
+/* eslint-disable */
+// @ts-nocheck
+/* eslint-env browser */
+
+import * as array from 'lib0/array'
+import * as map from 'lib0/map'
+import { Observable } from 'lib0/observable'
+import * as Y from 'yjs'
+
+/**
+ * @param {YMultiDocUndoManager} mum
+ * @param {'undo' | 'redo'} type
+ */
+const popStackItem = (mum, type) => {
+  const stack = type === 'undo' ? mum.undoStack : mum.redoStack
+  while (stack.length > 0) {
+    const um = /** @type {Y.UndoManager} */ (stack.pop())
+    const prevUmStack = type === 'undo' ? um.undoStack : um.redoStack
+    const stackItem = /** @type {any} */ (prevUmStack.pop())
+    let actionPerformed = false
+    if (type === 'undo') {
+      um.undoStack = [stackItem]
+      actionPerformed = um.undo() !== null
+      um.undoStack = prevUmStack
+    } else {
+      um.redoStack = [stackItem]
+      actionPerformed = um.redo() !== null
+      um.redoStack = prevUmStack
+    }
+    if (actionPerformed) {
+      return stackItem
+    }
+  }
+  return null
+}
+
+/**
+ * @extends Observable<any>
+ */
+export class YMultiDocUndoManager extends Observable {
+  /**
+   * @param {Y.AbstractType<any>|Array<Y.AbstractType<any>>} typeScope Accepts either a single type, or an array of types
+   * @param {ConstructorParameters<typeof Y.UndoManager>[1]} opts
+   */
+  constructor (typeScope = [], opts = {}) {
+    super()
+    /**
+     * @type {Map<Y.Doc, Y.UndoManager>}
+     */
+    this.docs = new Map()
+    this.trackedOrigins = opts.trackedOrigins || new Set([null])
+    opts.trackedOrigins = this.trackedOrigins
+    this._defaultOpts = opts
+    /**
+     * @type {Array<Y.UndoManager>}
+     */
+    this.undoStack = []
+    /**
+     * @type {Array<Y.UndoManager>}
+     */
+    this.redoStack = []
+    this.addToScope(typeScope)
+  }
+
+  /**
+   * @param {Array<Y.AbstractType<any>> | Y.AbstractType<any>} ytypes
+   */
+  addToScope (ytypes) {
+    ytypes = array.isArray(ytypes) ? ytypes : [ytypes]
+    ytypes.forEach(ytype => {
+      const ydoc = /** @type {Y.Doc} */ (ytype.doc)
+      const um = map.setIfUndefined(this.docs, ydoc, () => {
+        const um = new Y.UndoManager([ytype], this._defaultOpts)
+        um.on('stack-cleared', /** @param {any} opts */ ({ undoStackCleared, redoStackCleared }) => {
+          this.clear(undoStackCleared, redoStackCleared)
+        })
+        ydoc.on('destroy', () => {
+          this.docs.delete(ydoc)
+          this.undoStack = this.undoStack.filter(um => um.doc !== ydoc)
+          this.redoStack = this.redoStack.filter(um => um.doc !== ydoc)
+        })
+        um.on('stack-item-added', /** @param {any} change */ change => {
+          const stack = change.type === 'undo' ? this.undoStack : this.redoStack
+          stack.push(um)
+          this.emit('stack-item-added', [{ ...change, ydoc: ydoc }, this])
+        })
+        um.on('stack-item-updated', /** @param {any} change */ change => {
+          this.emit('stack-item-updated', [{ ...change, ydoc }, this])
+        })
+        um.on('stack-item-popped', /** @param {any} change */ change => {
+          this.emit('stack-item-popped', [{ ...change, ydoc }, this])
+        })
+        // if doc is destroyed
+        // emit events from um to multium
+        return um
+      })
+      /* c8 ignore next 4 */
+      if (um.scope.every(yt => yt !== ytype)) {
+        um.scope.push(ytype)
+      }
+    })
+  }
+
+  /**
+   * @param {any} origin
+   */
+  /* c8 ignore next 3 */
+  addTrackedOrigin (origin) {
+    this.trackedOrigins.add(origin)
+  }
+
+  /**
+   * @param {any} origin
+   */
+  /* c8 ignore next 3 */
+  removeTrackedOrigin (origin) {
+    this.trackedOrigins.delete(origin)
+  }
+
+  /**
+   * Undo last changes on type.
+   *
+   * @return {any?} Returns StackItem if a change was applied
+   */
+  undo () {
+    return popStackItem(this, 'undo')
+  }
+
+  /**
+   * Redo last undo operation.
+   *
+   * @return {any?} Returns StackItem if a change was applied
+   */
+  redo () {
+    return popStackItem(this, 'redo')
+  }
+
+  clear (clearUndoStack = true, clearRedoStack = true) {
+    /* c8 ignore next */
+    if ((clearUndoStack && this.canUndo()) || (clearRedoStack && this.canRedo())) {
+      this.docs.forEach(um => {
+        /* c8 ignore next */
+        clearUndoStack && (this.undoStack = [])
+        /* c8 ignore next */
+        clearRedoStack && (this.redoStack = [])
+        um.clear(clearUndoStack, clearRedoStack)
+      })
+      this.emit('stack-cleared', [{ undoStackCleared: clearUndoStack, redoStackCleared: clearRedoStack }])
+    }
+  }
+
+  /* c8 ignore next 5 */
+  stopCapturing () {
+    this.docs.forEach(um => {
+      um.stopCapturing()
+    })
+  }
+
+  /**
+   * Are undo steps available?
+   *
+   * @return {boolean} `true` if undo is possible
+   */
+  canUndo () {
+    return this.undoStack.length > 0
+  }
+
+  /**
+   * Are redo steps available?
+   *
+   * @return {boolean} `true` if redo is possible
+   */
+  canRedo () {
+    return this.redoStack.length > 0
+  }
+
+  destroy () {
+    this.docs.forEach(um => um.destroy())
+    super.destroy()
+  }
+}
+
+/**
+ * @todo remove
+ * @deprecated Use YMultiDocUndoManager instead
+ */
+export const MultiDocUndoManager = YMultiDocUndoManager


### PR DESCRIPTION

## What?

Use `YMultiDocUndoManager` from `y-utilities` so that we can provide a single UndoManager for multiple bootstrapped entities. This resolves the big `CAUTION / TODO` in the SyncProvider.

- Warehouse the `YMultiDocUndoManager` code in the repo to avoid another dependency that must be addressed in Webpack by plugins.
- Make `UndoManager` a singleton.
- Increase `captureTimeout` to 250ms.
- Remove `ignoreRemoteMapChanges=false`. I couldn't observe any effect of this setting and the comment didn't make clear why it was set to `true` (non-default). @ingeniumed If this is important can you restore it with a explanatory comment?
