### PR TITLE
Use V2 update format everywhere

### DIFF
--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -153,7 +153,7 @@ export class SyncProvider {
 		// Apply the initial document to the current document as a singular update.
 		if ( initialDoc ) {
 			ydoc.transact( () => {
-				Y.applyUpdate( ydoc, Y.encodeStateAsUpdate( initialDoc ) );
+				Y.applyUpdate( ydoc, Y.encodeStateAsUpdateV2( initialDoc ) );
 			}, LOCAL_SYNC_PROVIDER_ORIGIN );
 		}
 

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -153,7 +153,7 @@ export class SyncProvider {
 		// Apply the initial document to the current document as a singular update.
 		if ( initialDoc ) {
 			ydoc.transact( () => {
-				Y.applyUpdate( ydoc, Y.encodeStateAsUpdateV2( initialDoc ) );
+				Y.applyUpdateV2( ydoc, Y.encodeStateAsUpdateV2( initialDoc ) );
 			}, LOCAL_SYNC_PROVIDER_ORIGIN );
 		}
 


### PR DESCRIPTION
### Description

While working on reducing the size of the yjs doc, I realized we should be using the V2 APIs as much as possible. They are a lot better at compressing the updates down, and applying em to the doc. So this ensures that we use it throughout the fork.