### PR TITLE
Add tests for the changes made in the core-data package

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -81,7 +81,6 @@ export const getEntityRecord =
 		try {
 			// Entity supports configs,
 			if ( query !== undefined && query._fields ) {
-				// @todo how does this work? What is happening here?
 				// If requesting specific fields, items and query association to said
 				// records are stored by ID reference. Thus, fields must always include
 				// the ID.
@@ -97,13 +96,21 @@ export const getEntityRecord =
 				};
 			}
 
-			// Disable reason: While true that an early return could leave `path`
-			// unused, it's important that path is derived using the query prior to
-			// additional query modifications in the condition below, since those
-			// modifications are relevant to how the data is tracked in state, and not
-			// for how the request is made to the REST API.
+			if ( query !== undefined && query._fields ) {
+				// The resolution cache won't consider query as reusable based on the
+				// fields, so it's tested here, prior to initiating the REST request,
+				// and without causing `getEntityRecord` resolution to occur.
+				const hasRecord = select.hasEntityRecord(
+					kind,
+					name,
+					key,
+					query
+				);
+				if ( hasRecord ) {
+					return;
+				}
+			}
 
-			// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 			const path = addQueryArgs(
 				entityConfig.baseURL + ( key ? '/' + key : '' ),
 				{
@@ -111,18 +118,6 @@ export const getEntityRecord =
 					...query,
 				}
 			);
-
-			if ( query !== undefined && query._fields ) {
-				query = { ...query, include: [ key ] };
-
-				// The resolution cache won't consider query as reusable based on the
-				// fields, so it's tested here, prior to initiating the REST request,
-				// and without causing `getEntityRecords` resolution to occur.
-				const hasRecords = select.hasEntityRecords( kind, name, query );
-				if ( hasRecords ) {
-					return;
-				}
-			}
 
 			const response = await apiFetch( { path, parse: false } );
 			const record = await response.json();

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -5,6 +5,16 @@ import apiFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
 
+// Mock the sync provider
+jest.mock( '../sync', () => ( {
+	getSyncProvider: jest.fn( () => ( {
+		updateCRDTDoc: jest.fn(),
+	} ) ),
+} ) );
+
+// Mock logEntityDeprecation
+jest.mock( '../utils/log-entity-deprecation', () => jest.fn() );
+
 /**
  * Internal dependencies
  */
@@ -19,6 +29,8 @@ import {
 	__experimentalBatch,
 } from '../actions';
 
+import { getSyncProvider } from '../sync';
+
 jest.mock( '../batch', () => {
 	const { createBatch } = jest.requireActual( '../batch' );
 	return {
@@ -29,15 +41,37 @@ jest.mock( '../batch', () => {
 } );
 
 describe( 'editEntityRecord', () => {
+	let select, dispatch, mockUndoManager;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUndoManager = {
+			addRecord: jest.fn(),
+		};
+
+		select = {
+			getEntityConfig: jest.fn(),
+			getRawEntityRecord: jest.fn(),
+			getEditedEntityRecord: jest.fn(),
+			getUndoManager: jest.fn( () => mockUndoManager ),
+		};
+
+		dispatch = jest.fn();
+
+		getSyncProvider.mockReturnValue( {
+			updateCRDTDoc: jest.fn(),
+		} );
+	} );
+
 	it( 'throws when the edited entity does not have a loaded config.', async () => {
 		const entityConfig = {
 			kind: 'someKind',
 			name: 'someName',
 			id: 'someId',
 		};
-		const select = {
-			getEntityConfig: jest.fn(),
-		};
+		select.getEntityConfig.mockReturnValue( null );
+
 		const fulfillment = () =>
 			editEntityRecord(
 				entityConfig.kind,
@@ -49,6 +83,379 @@ describe( 'editEntityRecord', () => {
 			`The entity being edited (${ entityConfig.kind }, ${ entityConfig.name }) does not have a loaded config.`
 		);
 		expect( select.getEntityConfig ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'dispatches EDIT_ENTITY_RECORD action with basic edits and no sync', () => {
+		const entityConfig = {
+			kind: 'postType',
+			name: 'post',
+			mergedEdits: {},
+		};
+		const record = {
+			id: 1,
+			title: 'Original Title',
+			content: 'Original Content',
+		};
+		const editedRecord = {
+			id: 1,
+			title: 'Original Title',
+			content: 'Original Content',
+		};
+		const edits = { title: 'New Title' };
+
+		select.getEntityConfig.mockReturnValue( entityConfig );
+		select.getRawEntityRecord.mockReturnValue( record );
+		select.getEditedEntityRecord.mockReturnValue( editedRecord );
+
+		editEntityRecord(
+			'postType',
+			'post',
+			1,
+			edits
+		)( { select, dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits,
+		} );
+		expect( mockUndoManager.addRecord ).toHaveBeenCalledWith(
+			[
+				{
+					id: { kind: 'postType', name: 'post', recordId: 1 },
+					changes: {
+						title: {
+							from: 'Original Title',
+							to: 'New Title',
+						},
+					},
+				},
+			],
+			undefined
+		);
+	} );
+
+	it( 'clears edits when they are equal to persisted values', () => {
+		const entityConfig = {
+			kind: 'postType',
+			name: 'post',
+			mergedEdits: {},
+		};
+		const record = {
+			id: 1,
+			title: 'Same Title',
+			content: 'Original Content',
+		};
+		const editedRecord = {
+			id: 1,
+			title: 'Same Title',
+			content: 'Original Content',
+		};
+		const edits = { title: undefined };
+
+		select.getEntityConfig.mockReturnValue( entityConfig );
+		select.getRawEntityRecord.mockReturnValue( record );
+		select.getEditedEntityRecord.mockReturnValue( editedRecord );
+
+		editEntityRecord(
+			'postType',
+			'post',
+			1,
+			edits
+		)( { select, dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits,
+		} );
+		expect( mockUndoManager.addRecord ).toHaveBeenCalledWith(
+			[
+				{
+					id: { kind: 'postType', name: 'post', recordId: 1 },
+					changes: {
+						title: {
+							from: 'Same Title',
+							to: undefined,
+						},
+					},
+				},
+			],
+			undefined
+		);
+	} );
+
+	it( 'handles merged edits configuration', () => {
+		const entityConfig = {
+			kind: 'postType',
+			name: 'post',
+			mergedEdits: { meta: true },
+		};
+		const record = {
+			id: 1,
+			title: 'Original Title',
+			meta: { key1: 'value1' },
+		};
+		const editedRecord = {
+			id: 1,
+			title: 'Original Title',
+			meta: { key1: 'value1', key2: 'value2' },
+		};
+		const edits = { meta: { key3: 'value3' } };
+
+		select.getEntityConfig.mockReturnValue( entityConfig );
+		select.getRawEntityRecord.mockReturnValue( record );
+		select.getEditedEntityRecord.mockReturnValue( editedRecord );
+
+		editEntityRecord(
+			'postType',
+			'post',
+			1,
+			edits
+		)( { select, dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				meta: { key1: 'value1', key2: 'value2', key3: 'value3' },
+			},
+		} );
+		expect( mockUndoManager.addRecord ).toHaveBeenCalledWith(
+			[
+				{
+					id: { kind: 'postType', name: 'post', recordId: 1 },
+					changes: {
+						meta: {
+							from: {
+								key1: 'value1',
+								key2: 'value2',
+							},
+							to: {
+								key3: 'value3',
+							},
+						},
+					},
+				},
+			],
+			undefined
+		);
+	} );
+
+	it( 'skips undo manager when undoIgnore option is true', () => {
+		const entityConfig = {
+			kind: 'postType',
+			name: 'post',
+			mergedEdits: {},
+		};
+		const record = { id: 1, title: 'Original Title' };
+		const editedRecord = { id: 1, title: 'Original Title' };
+		const edits = { title: 'New Title' };
+		const options = { undoIgnore: true };
+
+		select.getEntityConfig.mockReturnValue( entityConfig );
+		select.getRawEntityRecord.mockReturnValue( record );
+		select.getEditedEntityRecord.mockReturnValue( editedRecord );
+
+		editEntityRecord(
+			'postType',
+			'post',
+			1,
+			edits,
+			options
+		)( { select, dispatch } );
+
+		expect( mockUndoManager.addRecord ).not.toHaveBeenCalled();
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				title: 'New Title',
+			},
+		} );
+	} );
+
+	it( 'passes isCached option to undo manager', () => {
+		const entityConfig = {
+			kind: 'postType',
+			name: 'post',
+			mergedEdits: {},
+		};
+		const record = { id: 1, title: 'Original Title' };
+		const editedRecord = { id: 1, title: 'Original Title' };
+		const edits = { title: 'New Title' };
+		const options = { isCached: true };
+
+		select.getEntityConfig.mockReturnValue( entityConfig );
+		select.getRawEntityRecord.mockReturnValue( record );
+		select.getEditedEntityRecord.mockReturnValue( editedRecord );
+
+		editEntityRecord(
+			'postType',
+			'post',
+			1,
+			edits,
+			options
+		)( { select, dispatch } );
+
+		expect( mockUndoManager.addRecord ).toHaveBeenCalledWith(
+			[
+				{
+					id: { kind: 'postType', name: 'post', recordId: 1 },
+					changes: {
+						title: {
+							from: 'Original Title',
+							to: 'New Title',
+						},
+					},
+				},
+			],
+			true
+		);
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				title: 'New Title',
+			},
+		} );
+	} );
+
+	it( 'handles multiple simultaneous edits', () => {
+		const entityConfig = {
+			kind: 'postType',
+			name: 'post',
+			mergedEdits: {},
+		};
+		const record = {
+			id: 1,
+			title: 'Original Title',
+			content: 'Original Content',
+			status: 'draft',
+		};
+		const editedRecord = {
+			id: 1,
+			title: 'Original Title',
+			content: 'Original Content',
+			status: 'draft',
+		};
+		const edits = {
+			title: 'New Title',
+			content: 'New Content',
+			status: 'publish',
+		};
+
+		select.getEntityConfig.mockReturnValue( entityConfig );
+		select.getRawEntityRecord.mockReturnValue( record );
+		select.getEditedEntityRecord.mockReturnValue( editedRecord );
+
+		editEntityRecord(
+			'postType',
+			'post',
+			1,
+			edits
+		)( { select, dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: {
+				title: 'New Title',
+				content: 'New Content',
+				status: 'publish',
+			},
+		} );
+
+		expect( mockUndoManager.addRecord ).toHaveBeenCalledWith(
+			[
+				{
+					id: { kind: 'postType', name: 'post', recordId: 1 },
+					changes: {
+						title: { from: 'Original Title', to: 'New Title' },
+						content: {
+							from: 'Original Content',
+							to: 'New Content',
+						},
+						status: { from: 'draft', to: 'publish' },
+					},
+				},
+			],
+			undefined
+		);
+	} );
+
+	it( 'works correctly with sync-enabled entity config', () => {
+		globalThis.window.__experimentalEnableSync = true;
+		const syncConfig = { enabled: true };
+		// Test that sync-related config doesn't break normal functionality
+
+		const entityConfig = {
+			kind: 'postType',
+			name: 'post',
+			mergedEdits: {},
+			syncConfig,
+		};
+		const record = { id: 1, title: 'Original Title' };
+		const editedRecord = { id: 1, title: 'Original Title' };
+		const edits = { title: 'New Title' };
+
+		select.getEntityConfig.mockReturnValue( entityConfig );
+		select.getRawEntityRecord.mockReturnValue( record );
+		select.getEditedEntityRecord.mockReturnValue( editedRecord );
+
+		editEntityRecord(
+			'postType',
+			'post',
+			1,
+			edits
+		)( { select, dispatch } );
+
+		// Normal functionality should work regardless of sync config
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'EDIT_ENTITY_RECORD',
+			kind: 'postType',
+			name: 'post',
+			recordId: 1,
+			edits: { title: 'New Title' },
+		} );
+
+		expect( mockUndoManager.addRecord ).toHaveBeenCalledWith(
+			[
+				{
+					id: { kind: 'postType', name: 'post', recordId: 1 },
+					changes: {
+						title: {
+							from: 'Original Title',
+							to: 'New Title',
+						},
+					},
+				},
+			],
+			undefined
+		);
+
+		expect( getSyncProvider ).toBeDefined();
+		const mockUpdateCRDTDoc = getSyncProvider().updateCRDTDoc;
+		expect( mockUpdateCRDTDoc ).toBeDefined();
+		expect( mockUpdateCRDTDoc ).toHaveBeenCalledWith(
+			syncConfig,
+			record,
+			edits,
+			'gutenberg'
+		);
+		delete globalThis.window.__experimentalEnableSync;
 	} );
 } );
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -914,6 +914,169 @@ describe( 'saveEntityRecord', () => {
 
 		expect( result ).toBe( postType );
 	} );
+
+	it( 'handles sync functionality when experimental sync is enabled', async () => {
+		globalThis.window.__experimentalEnableSync = true;
+
+		const mockCreateEntityMeta = jest
+			.fn()
+			.mockResolvedValue( { syncMeta: 'test' } );
+		const mockUpdateLastPersistedDate = jest.fn();
+		getSyncProvider.mockReturnValue( {
+			createEntityMeta: mockCreateEntityMeta,
+			updateLastPersistedDate: mockUpdateLastPersistedDate,
+		} );
+
+		const post = { id: 10, title: 'test post', meta: { existing: 'data' } };
+		const configs = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				syncConfig: { enabled: true },
+			},
+		];
+		const select = {
+			getRawEntityRecord: () => post,
+		};
+		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+
+		const updatedRecord = { ...post, id: 10 };
+		apiFetch.mockImplementation( () => updatedRecord );
+
+		const result = await saveEntityRecord(
+			'postType',
+			'post',
+			post
+		)( { select, dispatch, resolveSelect } );
+
+		// Verify createEntityMeta was called before persisting
+		expect( mockCreateEntityMeta ).toHaveBeenCalledWith(
+			{ enabled: true },
+			{
+				id: 10,
+				title: 'test post',
+				meta: { existing: 'data' },
+			}
+		);
+
+		// Verify the request was made with merged meta
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/posts/10',
+			method: 'PUT',
+			data: {
+				...post,
+				meta: {
+					existing: 'data',
+					syncMeta: 'test',
+				},
+			},
+		} );
+
+		// Verify updateLastPersistedDate was called after successful save
+		expect( mockUpdateLastPersistedDate ).toHaveBeenCalledWith(
+			{ enabled: true },
+			post
+		);
+
+		expect( result ).toBe( updatedRecord );
+
+		delete globalThis.window.__experimentalEnableSync;
+	} );
+
+	it( 'skips sync when experimental sync is disabled', async () => {
+		const mockCreateEntityMeta = jest.fn();
+		const mockUpdateLastPersistedDate = jest.fn();
+		getSyncProvider.mockReturnValue( {
+			createEntityMeta: mockCreateEntityMeta,
+			updateLastPersistedDate: mockUpdateLastPersistedDate,
+		} );
+
+		const post = { id: 10, title: 'test post', meta: { existing: 'data' } };
+		const configs = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				syncConfig: { enabled: true },
+			},
+		];
+		const select = {
+			getRawEntityRecord: () => post,
+		};
+		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+
+		const updatedRecord = { ...post, id: 10 };
+		apiFetch.mockImplementation( () => updatedRecord );
+
+		const result = await saveEntityRecord(
+			'postType',
+			'post',
+			post
+		)( { select, dispatch, resolveSelect } );
+
+		// Verify sync functions were not called
+		expect( mockCreateEntityMeta ).not.toHaveBeenCalled();
+		expect( mockUpdateLastPersistedDate ).not.toHaveBeenCalled();
+
+		// Verify normal save still works
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/posts/10',
+			method: 'PUT',
+			data: post,
+		} );
+
+		expect( result ).toBe( updatedRecord );
+	} );
+
+	it( 'skips sync when entity has no syncConfig', async () => {
+		globalThis.window.__experimentalEnableSync = true;
+
+		const mockCreateEntityMeta = jest.fn();
+		const mockUpdateLastPersistedDate = jest.fn();
+		getSyncProvider.mockReturnValue( {
+			createEntityMeta: mockCreateEntityMeta,
+			updateLastPersistedDate: mockUpdateLastPersistedDate,
+		} );
+
+		const post = { id: 10, title: 'test post', meta: { existing: 'data' } };
+		const configs = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				// No syncConfig property
+			},
+		];
+		const select = {
+			getRawEntityRecord: () => post,
+		};
+		const resolveSelect = { getEntitiesConfig: jest.fn( () => configs ) };
+
+		const updatedRecord = { ...post, id: 10, updated: true };
+		apiFetch.mockImplementation( () => updatedRecord );
+
+		const result = await saveEntityRecord(
+			'postType',
+			'post',
+			post
+		)( { select, dispatch, resolveSelect } );
+
+		// Verify sync functions were not called
+		expect( mockCreateEntityMeta ).not.toHaveBeenCalled();
+		expect( mockUpdateLastPersistedDate ).not.toHaveBeenCalled();
+
+		// Verify normal save still works
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/posts/10',
+			method: 'PUT',
+			data: post,
+		} );
+
+		expect( result ).toBe( updatedRecord );
+
+		delete globalThis.window.__experimentalEnableSync;
+	} );
 } );
 
 describe( 'receiveUserPermission', () => {

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -100,3 +100,64 @@ describe( 'loadTaxonomyEntities', () => {
 		expect( entities[ 0 ].supportsPagination ).toBe( true );
 	} );
 } );
+
+describe( 'loadPostTypeEntities', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'should add required properties to post type entities', async () => {
+		const mockPostTypes = {
+			post: {
+				name: 'Posts',
+				rest_base: 'posts',
+				rest_namespace: 'wp/v2',
+				slug: 'post',
+				supports: {
+					'custom-fields': true,
+					editor: true,
+					'collaborative-editing': true,
+				},
+			},
+		};
+
+		apiFetch.mockResolvedValueOnce( mockPostTypes );
+
+		const postTypeLoader = additionalEntityConfigLoaders.find(
+			( loader ) => loader.kind === 'postType'
+		);
+		const entities = await postTypeLoader.loadEntities();
+
+		expect( entities[ 0 ].supportsPagination ).toBe( true );
+		expect( entities[ 0 ].transientEdits ).toEqual( {
+			blocks: true,
+			selection: true,
+		} );
+		expect( entities[ 0 ].mergedEdits ).toEqual( { meta: true } );
+		expect( entities[ 0 ].rawAttributes ).toBeDefined();
+		expect( entities[ 0 ].__unstable_rest_base ).toBe( 'posts' );
+		expect( entities[ 0 ].syncConfig ).toBeDefined();
+		expect( entities[ 0 ].syncConfig.enabled ).toBe( true );
+		expect( typeof entities[ 0 ].syncConfig.applyChangesToCRDTDoc ).toBe(
+			'function'
+		);
+		expect( typeof entities[ 0 ].syncConfig.getChangesFromCRDTDoc ).toBe(
+			'function'
+		);
+		expect( typeof entities[ 0 ].syncConfig.getInitialObjectData ).toBe(
+			'function'
+		);
+		expect( typeof entities[ 0 ].syncConfig.getObjectId ).toBe(
+			'function'
+		);
+		expect( entities[ 0 ].syncConfig.objectType ).toBe( 'postType/post' );
+		expect( entities[ 0 ].syncConfig.supports ).toEqual( {
+			awareness: true,
+			crdtPersistence: true,
+			undo: true,
+		} );
+		expect( entities[ 0 ].syncConfig.syncedProperties ).toBeDefined();
+		expect( typeof entities[ 0 ].getRevisionsUrl ).toBe( 'function' );
+		expect( entities[ 0 ].revisionKey ).toBe( 'id' );
+	} );
+} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -5,6 +5,13 @@ import triggerFetch from '@wordpress/api-fetch';
 
 jest.mock( '@wordpress/api-fetch' );
 
+// Mock the sync provider
+jest.mock( '../sync', () => ( {
+	getSyncProvider: jest.fn( () => ( {
+		bootstrap: jest.fn(),
+	} ) ),
+} ) );
+
 /**
  * Internal dependencies
  */
@@ -16,6 +23,7 @@ import {
 	getAutosaves,
 	getCurrentUser,
 } from '../resolvers';
+import { getSyncProvider } from '../sync';
 
 describe( 'getEntityRecord', () => {
 	const POST_TYPE = { slug: 'post' };
@@ -41,6 +49,7 @@ describe( 'getEntityRecord', () => {
 			finishResolutions: jest.fn(),
 		} );
 		triggerFetch.mockReset();
+		getSyncProvider.mockClear();
 	} );
 
 	it( 'yields with requested post type', async () => {
@@ -110,6 +119,158 @@ describe( 'getEntityRecord', () => {
 		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(
 			1
 		);
+	} );
+
+	it( 'bootstraps sync provider when experimentalEnableSync is enabled', async () => {
+		const POST_RECORD = { id: 1, title: 'Test Post' };
+		const POST_RESPONSE = {
+			json: () => Promise.resolve( POST_RECORD ),
+			headers: {
+				get: () => null,
+			},
+		};
+		const ENTITIES_WITH_SYNC = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				baseURLParams: { context: 'edit' },
+				syncConfig: {
+					enabled: true,
+					objectType: 'postType/post',
+				},
+			},
+		];
+
+		window.__experimentalEnableSync = true;
+		const mockBootstrap = jest.fn();
+		getSyncProvider.mockReturnValue( {
+			bootstrap: mockBootstrap,
+		} );
+
+		const resolveSelectWithSync = {
+			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
+			getEditedEntityRecord: jest.fn(),
+		};
+
+		triggerFetch.mockImplementation( () => POST_RESPONSE );
+
+		await getEntityRecord(
+			'postType',
+			'post',
+			1
+		)( {
+			dispatch,
+			registry,
+			resolveSelect: resolveSelectWithSync,
+		} );
+
+		// Verify bootstrap was called with correct arguments
+		expect( mockBootstrap ).toHaveBeenCalledTimes( 1 );
+		expect( mockBootstrap ).toHaveBeenCalledWith(
+			ENTITIES_WITH_SYNC[ 0 ].syncConfig,
+			POST_RECORD,
+			expect.objectContaining( {
+				editRecord: expect.any( Function ),
+				getEditedRecord: expect.any( Function ),
+				refetchPersistedRecord: expect.any( Function ),
+			} )
+		);
+
+		delete window.__experimentalEnableSync;
+	} );
+
+	it( 'does not bootstrap sync when query is present', async () => {
+		const POST_RECORD = { id: 1, title: 'Test Post' };
+		const POST_RESPONSE = {
+			json: () => Promise.resolve( POST_RECORD ),
+			headers: {
+				get: () => null,
+			},
+		};
+		const ENTITIES_WITH_SYNC = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				baseURLParams: { context: 'edit' },
+				syncConfig: {
+					enabled: true,
+					objectType: 'postType/post',
+				},
+			},
+		];
+
+		window.__experimentalEnableSync = true;
+
+		const mockBootstrap = jest.fn();
+		getSyncProvider.mockReturnValue( {
+			bootstrap: mockBootstrap,
+		} );
+
+		const resolveSelectWithSync = {
+			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
+		};
+
+		triggerFetch.mockImplementation( () => POST_RESPONSE );
+
+		// Call with a query parameter
+		await getEntityRecord( 'postType', 'post', 1, { context: 'view' } )( {
+			dispatch,
+			registry,
+			resolveSelect: resolveSelectWithSync,
+		} );
+
+		// Verify bootstrap was NOT called
+		expect( mockBootstrap ).not.toHaveBeenCalled();
+
+		delete window.__experimentalEnableSync;
+	} );
+
+	it( 'does not bootstrap sync when experimentalEnableSync is disabled', async () => {
+		const POST_RECORD = { id: 1, title: 'Test Post' };
+		const POST_RESPONSE = {
+			json: () => Promise.resolve( POST_RECORD ),
+			headers: {
+				get: () => null,
+			},
+		};
+		const ENTITIES_WITH_SYNC = [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				baseURLParams: { context: 'edit' },
+				syncConfig: {
+					enabled: true,
+					objectType: 'postType/post',
+				},
+			},
+		];
+
+		const mockBootstrap = jest.fn();
+		getSyncProvider.mockReturnValue( {
+			bootstrap: mockBootstrap,
+		} );
+
+		const resolveSelectWithSync = {
+			getEntitiesConfig: jest.fn( () => ENTITIES_WITH_SYNC ),
+		};
+
+		triggerFetch.mockImplementation( () => POST_RESPONSE );
+
+		await getEntityRecord(
+			'postType',
+			'post',
+			1
+		)( {
+			dispatch,
+			registry,
+			resolveSelect: resolveSelectWithSync,
+		} );
+
+		// Verify bootstrap was NOT called
+		expect( mockBootstrap ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -45,7 +45,6 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-core-data',
 			'wp-editor',
 			'wp-router',
-			'wp-sync',
 			'wp-url',
 			'wp-widgets',
 		);

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -45,6 +45,7 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-core-data',
 			'wp-editor',
 			'wp-router',
+			'wp-sync',
 			'wp-url',
 			'wp-widgets',
 		);


### PR DESCRIPTION
### Description

This PR does two things:

- Add tests for the changes made to the core-data package. 
- Revert a modification that Kevin/we made in the `getEntityRecord` to the way the method's caching works that diverts away from Gutenberg. I noticed in my previous PR that the store.js test that tested if repeated calls to `getEntityRecord` would return from the store kept failing. This was because the `key` was taken out of the `hasEntityRecord` call. 

I'll be making another follow up PR to focus on adding tests to the sync package. This PR is big enough as is.