### PR TITLE
Add NOTICE.md for GPLv3 license

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,12 @@
+## Gutenberg
+Copyright 2016-2025 by the contributors
+
+This product includes software developed at the Automattic, and is a fork of the original project.
+
+This version of the project is released under the GNU General Public License, version 3 (GPLv3) only, due to the inclusion of code licensed under the Apache License, Version 2.0. 
+
+The Apache License, Version 2.0, is compatible with GPLv3 but not with GPLv2. Therefore, this distribution is licensed under GPLv3 to ensure compliance.
+
+The Apache License, Version 2.0, can be found at http://www.apache.org/licenses/LICENSE-2.0.
+
+The GNU General Public License, version 3, can be found at https://www.gnu.org/licenses/gpl-3.0.html.


### PR DESCRIPTION
Adds a NOTICE.md file to say that we're licensing only under GPLv3 because of our `fast-diff` dependency being Apache.