### PR TITLE
Update block syncing to account for invalid blocks

### DIFF
--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -65,6 +65,13 @@ export function applyPostChangesToCRDTDoc(
 
 		switch ( key ) {
 			case 'blocks': {
+				// Account for the case where the content has some invalid blocks, and as a result
+				// the blocks are undefined but the content is not.
+				if ( changes.content && ! changes.blocks ) {
+					// Pull in the parsed blocks from the content, and use that as the new value.
+					newValue = parse( getRawValue( changes.content ) );
+				}
+
 				let currentBlocks = ymap.get( 'blocks' ) as Y.Array< YBlock >;
 
 				// Initialize.

--- a/packages/core-data/src/utils/crdt.ts
+++ b/packages/core-data/src/utils/crdt.ts
@@ -68,8 +68,13 @@ export function applyPostChangesToCRDTDoc(
 				// Account for the case where the content has some invalid blocks, and as a result
 				// the blocks are undefined but the content is not.
 				if ( changes.content && ! changes.blocks ) {
-					// Pull in the parsed blocks from the content, and use that as the new value.
-					newValue = parse( getRawValue( changes.content ) );
+					try {
+						// Pull in the parsed blocks from the content, and use that as the new value.
+						newValue = parse( getRawValue( changes.content ) );
+					} catch ( e ) {
+						// No-op as one of the blocks is expected to be invalid.
+						// This ensures that neither the blocks, nor the content are overwritten.
+					}
 				}
 
 				let currentBlocks = ymap.get( 'blocks' ) as Y.Array< YBlock >;


### PR DESCRIPTION
### Description

Currently, using invalid markup or messing up the markup via the code editor leads to content being lost. This is different behaviour than if RTC wasn't turned on where the block recovery errors would crop up.

https://github.com/user-attachments/assets/14f5548c-c435-4561-bc26-d1b9a7e8f37c

The problem comes from the content being defined (albeit problematic), but the blocks being empty. So the key here is to, parse out the blocks from content, account for errors being thrown from the invalid markup, and then using that as the blocks going forward. This matches the behaviour without RTC being turned on, and avoid content being lost as well.

### Testing

- Follow the screen recording on vip-rtc, and on this branch to see the difference in behaviour.